### PR TITLE
Chore/infra/introduce liquibase migrations

### DIFF
--- a/services/auth-service/pom.xml
+++ b/services/auth-service/pom.xml
@@ -31,6 +31,10 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>

--- a/services/auth-service/src/main/java/com/app/auth/model/Otp.java
+++ b/services/auth-service/src/main/java/com/app/auth/model/Otp.java
@@ -21,7 +21,8 @@ import java.time.Instant;
 public class Otp {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "otps_sequence")
+    @SequenceGenerator(name = "otps_sequence", sequenceName = "otps_sequence", allocationSize = 50)
     @Column(name = "otp_id")
     private Long id;
 

--- a/services/auth-service/src/main/java/com/app/auth/model/Token.java
+++ b/services/auth-service/src/main/java/com/app/auth/model/Token.java
@@ -18,7 +18,9 @@ import java.time.Instant;
 public class Token {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "tokens_sequence")
+    @SequenceGenerator(name = "tokens_sequence", sequenceName = "tokens_sequence", allocationSize = 50)
+    @Column(name = "token_id")
     private Long TokenId;
 
     @Column(nullable = false, length = 1000)

--- a/services/auth-service/src/main/java/com/app/auth/model/User.java
+++ b/services/auth-service/src/main/java/com/app/auth/model/User.java
@@ -24,7 +24,8 @@ import java.util.stream.Collectors;
 public class User implements UserDetails {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "users_sequence")
+    @SequenceGenerator(name = "users_sequence", sequenceName = "users_sequence", allocationSize = 50)
     @Column(name = "user_id")
     private Long userId;
 

--- a/services/auth-service/src/main/resources/application.yml
+++ b/services/auth-service/src/main/resources/application.yml
@@ -14,11 +14,14 @@ spring:
   # JPA Configuration
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     show-sql: true
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+  liquibase:
+    change-log: classpath:db/changelog/db.changelog-master.xml
+    enabled: true
   # Redis Configuration (for token blacklisting)
   #redis:
   #  host: localhost

--- a/services/auth-service/src/main/resources/db/changelog/changes/001-create-users-table.xml
+++ b/services/auth-service/src/main/resources/db/changelog/changes/001-create-users-table.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="001-create-users-table" author="osama">
+        <preConditions onFail="MARK_RAN" onError="HALT"
+                       onFailMessage="Table 'users' already exists — skipping changeset 001-create-users-table"
+                       onErrorMessage="Precondition check failed unexpectedly for changeset 001-create-users-table — halting migration">
+            <not><tableExists tableName="users" schemaName="public"/></not>
+        </preConditions>
+        <createTable tableName="users">
+            <column name="user_id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" primaryKeyName="PK_users" nullable="false"/>
+            </column>
+            <column name="first_name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="last_name" type="VARCHAR(255)"/>
+            <column name="email" type="VARCHAR(255)">
+                <constraints nullable="false" unique="true" uniqueConstraintName="UQ_users_email"/>
+            </column>
+            <column name="password" type="VARCHAR(255)"/>
+            <column name="phone_number" type="VARCHAR(255)"/>
+            <column name="enabled" type="BOOLEAN" defaultValueBoolean="true">
+                <constraints nullable="false"/>
+            </column>
+            <column name="account_non_expired" type="BOOLEAN" defaultValueBoolean="true">
+                <constraints nullable="false"/>
+            </column>
+            <column name="account_non_locked" type="BOOLEAN" defaultValueBoolean="true">
+                <constraints nullable="false"/>
+            </column>
+            <column name="credentials_non_expired" type="BOOLEAN" defaultValueBoolean="true">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_at" type="TIMESTAMP WITH TIME ZONE">
+                <constraints nullable="false"/>
+            </column>
+            <column name="last_login_at" type="TIMESTAMP WITH TIME ZONE"/>
+            <column name="oauth_provider" type="VARCHAR(50)"/>
+            <column name="oauth_provider_id" type="VARCHAR(255)"/>
+            <column name="email_verified" type="BOOLEAN" defaultValueBoolean="false"/>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>

--- a/services/auth-service/src/main/resources/db/changelog/changes/002-create-user-roles-table.xml
+++ b/services/auth-service/src/main/resources/db/changelog/changes/002-create-user-roles-table.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!-- ElementCollection join table: @CollectionTable(name="user_roles", joinColumns=@JoinColumn(name="user_id")) -->
+    <!-- Enum column: @Column(name="role") -->
+    <changeSet id="002-create-user-roles-table" author="osama">
+        <preConditions onFail="MARK_RAN" onError="HALT"
+                       onFailMessage="Table 'user_roles' already exists — skipping changeset 002-create-user-roles-table"
+                       onErrorMessage="Precondition check failed unexpectedly for changeset 002-create-user-roles-table — halting migration">
+            <not><tableExists tableName="user_roles" schemaName="public"/></not>
+        </preConditions>
+        <createTable tableName="user_roles">
+            <column name="user_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="role" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint
+            baseTableName="user_roles"
+            baseColumnNames="user_id"
+            constraintName="FK_user_roles_user_id"
+            referencedTableName="users"
+            referencedColumnNames="user_id"
+            onDelete="CASCADE"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/services/auth-service/src/main/resources/db/changelog/changes/003-create-tokens-table.xml
+++ b/services/auth-service/src/main/resources/db/changelog/changes/003-create-tokens-table.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="003-create-tokens-table" author="osama">
+        <preConditions onFail="MARK_RAN" onError="HALT"
+                       onFailMessage="Table 'tokens' already exists — skipping changeset 003-create-tokens-table"
+                       onErrorMessage="Precondition check failed unexpectedly for changeset 003-create-tokens-table — halting migration">
+            <not><tableExists tableName="tokens" schemaName="public"/></not>
+        </preConditions>
+        <createTable tableName="tokens">
+            <column name="token_id" type="BIGINT" autoIncrement="true" >
+                <constraints primaryKey="true" primaryKeyName="PK_tokens" nullable="false"/>
+            </column>
+            <column name="token" type="VARCHAR(1000)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="token_type" type="VARCHAR(50)"/>
+            <column name="revoked" type="BOOLEAN" defaultValueBoolean="false"/>
+            <column name="expired" type="BOOLEAN" defaultValueBoolean="false"/>
+            <column name="user_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_at" type="TIMESTAMP WITH TIME ZONE">
+                <constraints nullable="false"/>
+            </column>
+            <column name="expires_at" type="TIMESTAMP WITH TIME ZONE">
+                <constraints nullable="false"/>
+            </column>
+            <column name="device_name" type="VARCHAR(255)"/>
+            <column name="device_type" type="VARCHAR(50)"/>
+            <column name="ip_address" type="VARCHAR(45)"/>
+            <column name="user_agent" type="VARCHAR(500)"/>
+            <column name="last_used_at" type="TIMESTAMP WITH TIME ZONE"/>
+        </createTable>
+
+        <addForeignKeyConstraint
+            baseTableName="tokens"
+            baseColumnNames="user_id"
+            constraintName="FK_tokens_user_id"
+            referencedTableName="users"
+            referencedColumnNames="user_id"
+            onDelete="CASCADE"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/services/auth-service/src/main/resources/db/changelog/changes/004-create-otps-table.xml
+++ b/services/auth-service/src/main/resources/db/changelog/changes/004-create-otps-table.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="004-create-otps-table" author="osama">
+        <preConditions onFail="MARK_RAN" onError="HALT"
+                       onFailMessage="Table 'otps' already exists — skipping changeset 004-create-otps-table"
+                       onErrorMessage="Precondition check failed unexpectedly for changeset 004-create-otps-table — halting migration">
+            <not><tableExists tableName="otps" schemaName="public"/></not>
+        </preConditions>
+        <createTable tableName="otps">
+            <column name="otp_id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" primaryKeyName="PK_otps" nullable="false"/>
+            </column>
+            <column name="email" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="code" type="VARCHAR(6)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="type" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="status" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_at" type="TIMESTAMP WITH TIME ZONE">
+                <constraints nullable="false"/>
+            </column>
+            <column name="expires_at" type="TIMESTAMP WITH TIME ZONE">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <createIndex indexName="idx_otp_email_type_status" tableName="otps">
+            <column name="email"/>
+            <column name="type"/>
+            <column name="status"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/services/auth-service/src/main/resources/db/changelog/changes/005-migrate-ids-to-sequences.xml
+++ b/services/auth-service/src/main/resources/db/changelog/changes/005-migrate-ids-to-sequences.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="005-create-sequence-users" author="osama">
+        <preConditions onFail="MARK_RAN" onError="HALT"
+                       onFailMessage="Sequence 'users_sequence' already exists — skipping"
+                       onErrorMessage="Precondition check failed unexpectedly for 005-create-sequence-users — halting migration">
+            <not><sequenceExists sequenceName="users_sequence" schemaName="public"/></not>
+        </preConditions>
+        <createSequence sequenceName="users_sequence" startValue="1" incrementBy="50"/>
+    </changeSet>
+
+    <changeSet id="005-drop-identity-users" author="osama" dbms="postgresql">
+        <sql>ALTER TABLE users ALTER COLUMN user_id DROP IDENTITY IF EXISTS</sql>
+    </changeSet>
+
+    <changeSet id="005-seed-sequence-users" author="osama" dbms="postgresql">
+        <sql>SELECT setval('users_sequence', GREATEST(COALESCE((SELECT MAX(user_id) FROM users), 0) + 500, 1))</sql>
+    </changeSet>
+
+    <changeSet id="005-create-sequence-tokens" author="osama">
+        <preConditions onFail="MARK_RAN" onError="HALT"
+                       onFailMessage="Sequence 'tokens_sequence' already exists — skipping"
+                       onErrorMessage="Precondition check failed unexpectedly for 005-create-sequence-tokens — halting migration">
+            <not><sequenceExists sequenceName="tokens_sequence" schemaName="public"/></not>
+        </preConditions>
+        <createSequence sequenceName="tokens_sequence" startValue="1" incrementBy="50"/>
+    </changeSet>
+
+    <changeSet id="005-drop-identity-tokens" author="osama" dbms="postgresql">
+        <sql>ALTER TABLE tokens ALTER COLUMN token_id DROP IDENTITY IF EXISTS</sql>
+    </changeSet>
+
+    <changeSet id="005-seed-sequence-tokens" author="osama" dbms="postgresql">
+        <sql>SELECT setval('tokens_sequence', GREATEST(COALESCE((SELECT MAX(token_id) FROM tokens), 0) + 500, 1))</sql>
+    </changeSet>
+
+    <changeSet id="005-create-sequence-otps" author="osama">
+        <preConditions onFail="MARK_RAN" onError="HALT"
+                       onFailMessage="Sequence 'otps_sequence' already exists — skipping"
+                       onErrorMessage="Precondition check failed unexpectedly for 005-create-sequence-otps — halting migration">
+            <not><sequenceExists sequenceName="otps_sequence" schemaName="public"/></not>
+        </preConditions>
+        <createSequence sequenceName="otps_sequence" startValue="1" incrementBy="50"/>
+    </changeSet>
+
+    <changeSet id="005-drop-identity-otps" author="osama" dbms="postgresql">
+        <sql>ALTER TABLE otps ALTER COLUMN otp_id DROP IDENTITY IF EXISTS</sql>
+    </changeSet>
+
+    <changeSet id="005-seed-sequence-otps" author="osama" dbms="postgresql">
+        <sql>SELECT setval('otps_sequence', GREATEST(COALESCE((SELECT MAX(otp_id) FROM otps), 0) + 500, 1))</sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/services/auth-service/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/services/auth-service/src/main/resources/db/changelog/db.changelog-master.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <includeAll path="db/changelog/changes/" relativeToChangelogFile="false"/>
+
+</databaseChangeLog>

--- a/services/main-service/pom.xml
+++ b/services/main-service/pom.xml
@@ -23,6 +23,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.liquibase</groupId>
+			<artifactId>liquibase-core</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/services/main-service/src/main/java/com/app/server/model/Comment.java
+++ b/services/main-service/src/main/java/com/app/server/model/Comment.java
@@ -18,7 +18,8 @@ import java.util.Set;
 @DynamicUpdate
 public class Comment {
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "comment_sequence")
+    @SequenceGenerator(name = "comment_sequence", sequenceName = "comment_sequence", allocationSize = 50)
     @Column(name = "comment_id")
     private Long commentId;
 

--- a/services/main-service/src/main/java/com/app/server/model/Profile.java
+++ b/services/main-service/src/main/java/com/app/server/model/Profile.java
@@ -17,7 +17,8 @@ import jakarta.persistence.*;
 @Builder
 public class Profile {
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "profile_sequence")
+    @SequenceGenerator(name = "profile_sequence", sequenceName = "profile_sequence", allocationSize = 50)
     private Long profileId;
 
     private String aboutUser;

--- a/services/main-service/src/main/resources/application.yml
+++ b/services/main-service/src/main/resources/application.yml
@@ -28,10 +28,13 @@ spring:
     # ======================= Hibernate =======================
     # Hibernate ddl auto (create, create-drop, validate, update)
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     show-sql: true
     #- avoid lazy initialization error.
     open-in-view: false
+  liquibase:
+    change-log: classpath:db/changelog/db.changelog-master.xml
+    enabled: true
   # ======================= File Limit =======================
   servlet:
     multipart:

--- a/services/main-service/src/main/resources/db/changelog/changes/001-create-sequences.xml
+++ b/services/main-service/src/main/resources/db/changelog/changes/001-create-sequences.xml
@@ -5,23 +5,57 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
-    <changeSet id="001-create-sequences" author="main-service">
-        <!-- Post: @SequenceGenerator(sequenceName="post_sequence", allocationSize=50) -->
+    <changeSet id="001-create-sequence-post" author="osama">
+        <preConditions onFail="MARK_RAN" onError="HALT"
+                       onFailMessage="Sequence 'post_sequence' already exists — skipping changeset 001-create-sequence-post"
+                       onErrorMessage="Precondition check failed unexpectedly for changeset 001-create-sequence-post — halting migration">
+            <not><sequenceExists sequenceName="post_sequence" schemaName="public"/></not>
+        </preConditions>
         <createSequence sequenceName="post_sequence" startValue="1" incrementBy="50"/>
+    </changeSet>
 
-        <!-- File: @SequenceGenerator(sequenceName="file_sequence", allocationSize=50) -->
+    <changeSet id="001-create-sequence-file" author="osama">
+        <preConditions onFail="MARK_RAN" onError="HALT"
+                       onFailMessage="Sequence 'file_sequence' already exists — skipping changeset 001-create-sequence-file"
+                       onErrorMessage="Precondition check failed unexpectedly for changeset 001-create-sequence-file — halting migration">
+            <not><sequenceExists sequenceName="file_sequence" schemaName="public"/></not>
+        </preConditions>
         <createSequence sequenceName="file_sequence" startValue="1" incrementBy="50"/>
+    </changeSet>
 
-        <!-- UserReaction: @SequenceGenerator(sequenceName="reaction_sequence", allocationSize=50) -->
+    <changeSet id="001-create-sequence-reaction" author="osama">
+        <preConditions onFail="MARK_RAN" onError="HALT"
+                       onFailMessage="Sequence 'reaction_sequence' already exists — skipping changeset 001-create-sequence-reaction"
+                       onErrorMessage="Precondition check failed unexpectedly for changeset 001-create-sequence-reaction — halting migration">
+            <not><sequenceExists sequenceName="reaction_sequence" schemaName="public"/></not>
+        </preConditions>
         <createSequence sequenceName="reaction_sequence" startValue="1" incrementBy="50"/>
+    </changeSet>
 
-        <!-- Address: @SequenceGenerator(sequenceName="address_sequence", allocationSize=50) -->
+    <changeSet id="001-create-sequence-address" author="osama">
+        <preConditions onFail="MARK_RAN" onError="HALT"
+                       onFailMessage="Sequence 'address_sequence' already exists — skipping changeset 001-create-sequence-address"
+                       onErrorMessage="Precondition check failed unexpectedly for changeset 001-create-sequence-address — halting migration">
+            <not><sequenceExists sequenceName="address_sequence" schemaName="public"/></not>
+        </preConditions>
         <createSequence sequenceName="address_sequence" startValue="1" incrementBy="50"/>
+    </changeSet>
 
-        <!-- Comment: @SequenceGenerator(sequenceName="comment_sequence", allocationSize=50) -->
+    <changeSet id="001-create-sequence-comment" author="osama">
+        <preConditions onFail="MARK_RAN" onError="HALT"
+                       onFailMessage="Sequence 'comment_sequence' already exists — skipping changeset 001-create-sequence-comment"
+                       onErrorMessage="Precondition check failed unexpectedly for changeset 001-create-sequence-comment — halting migration">
+            <not><sequenceExists sequenceName="comment_sequence" schemaName="public"/></not>
+        </preConditions>
         <createSequence sequenceName="comment_sequence" startValue="1" incrementBy="50"/>
+    </changeSet>
 
-        <!-- Profile: @SequenceGenerator(sequenceName="profile_sequence", allocationSize=50) -->
+    <changeSet id="001-create-sequence-profile" author="osama">
+        <preConditions onFail="MARK_RAN" onError="HALT"
+                       onFailMessage="Sequence 'profile_sequence' already exists — skipping changeset 001-create-sequence-profile"
+                       onErrorMessage="Precondition check failed unexpectedly for changeset 001-create-sequence-profile — halting migration">
+            <not><sequenceExists sequenceName="profile_sequence" schemaName="public"/></not>
+        </preConditions>
         <createSequence sequenceName="profile_sequence" startValue="1" incrementBy="50"/>
     </changeSet>
 

--- a/services/main-service/src/main/resources/db/changelog/changes/001-create-sequences.xml
+++ b/services/main-service/src/main/resources/db/changelog/changes/001-create-sequences.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="001-create-sequences" author="main-service">
+        <!-- Post: @SequenceGenerator(sequenceName="post_sequence", allocationSize=50) -->
+        <createSequence sequenceName="post_sequence" startValue="1" incrementBy="50"/>
+
+        <!-- File: @SequenceGenerator(sequenceName="file_sequence", allocationSize=50) -->
+        <createSequence sequenceName="file_sequence" startValue="1" incrementBy="50"/>
+
+        <!-- UserReaction: @SequenceGenerator(sequenceName="reaction_sequence", allocationSize=50) -->
+        <createSequence sequenceName="reaction_sequence" startValue="1" incrementBy="50"/>
+
+        <!-- Address: @SequenceGenerator(sequenceName="address_sequence", allocationSize=50) -->
+        <createSequence sequenceName="address_sequence" startValue="1" incrementBy="50"/>
+
+        <!-- Comment: @SequenceGenerator(sequenceName="comment_sequence", allocationSize=50) -->
+        <createSequence sequenceName="comment_sequence" startValue="1" incrementBy="50"/>
+
+        <!-- Profile: @SequenceGenerator(sequenceName="profile_sequence", allocationSize=50) -->
+        <createSequence sequenceName="profile_sequence" startValue="1" incrementBy="50"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/services/main-service/src/main/resources/db/changelog/changes/002-create-user-profiles-table.xml
+++ b/services/main-service/src/main/resources/db/changelog/changes/002-create-user-profiles-table.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!-- PK is assigned externally (synced from auth-service) — no auto-generation -->
+    <changeSet id="002-create-user-profiles-table" author="main-service">
+        <createTable tableName="user_profiles">
+            <column name="user_id" type="BIGINT">
+                <constraints primaryKey="true" primaryKeyName="PK_user_profiles" nullable="false"/>
+            </column>
+            <column name="first_name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="last_name" type="VARCHAR(255)"/>
+            <column name="email" type="VARCHAR(255)">
+                <constraints nullable="false" unique="true" uniqueConstraintName="UQ_user_profiles_email"/>
+            </column>
+            <column name="phone_number" type="VARCHAR(255)"/>
+            <column name="created_at" type="TIMESTAMP WITH TIME ZONE">
+                <constraints nullable="false"/>
+            </column>
+            <column name="synced_at" type="TIMESTAMP WITH TIME ZONE"/>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>

--- a/services/main-service/src/main/resources/db/changelog/changes/002-create-user-profiles-table.xml
+++ b/services/main-service/src/main/resources/db/changelog/changes/002-create-user-profiles-table.xml
@@ -6,7 +6,12 @@
         https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
     <!-- PK is assigned externally (synced from auth-service) — no auto-generation -->
-    <changeSet id="002-create-user-profiles-table" author="main-service">
+    <changeSet id="002-create-user-profiles-table" author="osama">
+        <preConditions onFail="MARK_RAN" onError="HALT"
+                       onFailMessage="Table 'user_profiles' already exists — skipping changeset 002-create-user-profiles-table"
+                       onErrorMessage="Precondition check failed unexpectedly for changeset 002-create-user-profiles-table — halting migration">
+            <not><tableExists tableName="user_profiles" schemaName="public"/></not>
+        </preConditions>
         <createTable tableName="user_profiles">
             <column name="user_id" type="BIGINT">
                 <constraints primaryKey="true" primaryKeyName="PK_user_profiles" nullable="false"/>

--- a/services/main-service/src/main/resources/db/changelog/changes/003-create-address-table.xml
+++ b/services/main-service/src/main/resources/db/changelog/changes/003-create-address-table.xml
@@ -5,7 +5,12 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
-    <changeSet id="003-create-address-table" author="main-service">
+    <changeSet id="003-create-address-table" author="osama">
+        <preConditions onFail="MARK_RAN" onError="HALT"
+                       onFailMessage="Table 'address' already exists — skipping changeset 003-create-address-table"
+                       onErrorMessage="Precondition check failed unexpectedly for changeset 003-create-address-table — halting migration">
+            <not><tableExists tableName="address" schemaName="public"/></not>
+        </preConditions>
         <createTable tableName="address">
             <column name="address_id" type="BIGINT" defaultValueSequenceNext="address_sequence">
                 <constraints primaryKey="true" primaryKeyName="PK_address" nullable="false"/>

--- a/services/main-service/src/main/resources/db/changelog/changes/003-create-address-table.xml
+++ b/services/main-service/src/main/resources/db/changelog/changes/003-create-address-table.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="003-create-address-table" author="main-service">
+        <createTable tableName="address">
+            <column name="address_id" type="BIGINT" defaultValueSequenceNext="address_sequence">
+                <constraints primaryKey="true" primaryKeyName="PK_address" nullable="false"/>
+            </column>
+            <column name="street" type="VARCHAR(255)"/>
+            <column name="city" type="VARCHAR(255)"/>
+            <column name="state" type="VARCHAR(255)"/>
+            <column name="country" type="VARCHAR(255)"/>
+            <column name="zip_code" type="VARCHAR(255)"/>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>

--- a/services/main-service/src/main/resources/db/changelog/changes/004-create-files-table.xml
+++ b/services/main-service/src/main/resources/db/changelog/changes/004-create-files-table.xml
@@ -6,7 +6,12 @@
         https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
     <!-- @Entity(name="files") — table name derived from entity name -->
-    <changeSet id="004-create-files-table" author="main-service">
+    <changeSet id="004-create-files-table" author="osama">
+        <preConditions onFail="MARK_RAN" onError="HALT"
+                       onFailMessage="Table 'files' already exists — skipping changeset 004-create-files-table"
+                       onErrorMessage="Precondition check failed unexpectedly for changeset 004-create-files-table — halting migration">
+            <not><tableExists tableName="files" schemaName="public"/></not>
+        </preConditions>
         <createTable tableName="files">
             <column name="file_id" type="BIGINT" defaultValueSequenceNext="file_sequence">
                 <constraints primaryKey="true" primaryKeyName="PK_files" nullable="false"/>

--- a/services/main-service/src/main/resources/db/changelog/changes/004-create-files-table.xml
+++ b/services/main-service/src/main/resources/db/changelog/changes/004-create-files-table.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!-- @Entity(name="files") — table name derived from entity name -->
+    <changeSet id="004-create-files-table" author="main-service">
+        <createTable tableName="files">
+            <column name="file_id" type="BIGINT" defaultValueSequenceNext="file_sequence">
+                <constraints primaryKey="true" primaryKeyName="PK_files" nullable="false"/>
+            </column>
+            <column name="file_name" type="VARCHAR(255)"/>
+            <column name="file_url" type="VARCHAR(128)"/>
+            <column name="file_type" type="VARCHAR(128)"/>
+            <column name="file_size_in_bytes" type="BIGINT" defaultValueNumeric="0"/>
+            <column name="file_extension" type="VARCHAR(64)"/>
+            <column name="file_description" type="VARCHAR(255)"/>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>

--- a/services/main-service/src/main/resources/db/changelog/changes/005-create-posts-table.xml
+++ b/services/main-service/src/main/resources/db/changelog/changes/005-create-posts-table.xml
@@ -5,7 +5,12 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
-    <changeSet id="005-create-posts-table" author="main-service">
+    <changeSet id="005-create-posts-table" author="osama">
+        <preConditions onFail="MARK_RAN" onError="HALT"
+                       onFailMessage="Table 'posts' already exists — skipping changeset 005-create-posts-table"
+                       onErrorMessage="Precondition check failed unexpectedly for changeset 005-create-posts-table — halting migration">
+            <not><tableExists tableName="posts" schemaName="public"/></not>
+        </preConditions>
         <createTable tableName="posts">
             <column name="post_id" type="BIGINT" defaultValueSequenceNext="post_sequence">
                 <constraints primaryKey="true" primaryKeyName="PK_posts" nullable="false"/>

--- a/services/main-service/src/main/resources/db/changelog/changes/005-create-posts-table.xml
+++ b/services/main-service/src/main/resources/db/changelog/changes/005-create-posts-table.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="005-create-posts-table" author="main-service">
+        <createTable tableName="posts">
+            <column name="post_id" type="BIGINT" defaultValueSequenceNext="post_sequence">
+                <constraints primaryKey="true" primaryKeyName="PK_posts" nullable="false"/>
+            </column>
+            <column name="content" type="VARCHAR(512)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="publicity" type="VARCHAR(50)" defaultValue="PUBLIC">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_at" type="TIMESTAMP WITH TIME ZONE">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP WITH TIME ZONE"/>
+            <column name="author_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint
+            baseTableName="posts"
+            baseColumnNames="author_id"
+            constraintName="FK_posts_author_id"
+            referencedTableName="user_profiles"
+            referencedColumnNames="user_id"
+            onDelete="CASCADE"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/services/main-service/src/main/resources/db/changelog/changes/006-create-post-files-table.xml
+++ b/services/main-service/src/main/resources/db/changelog/changes/006-create-post-files-table.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!-- ManyToMany join table between posts and files -->
+    <changeSet id="006-create-post-files-table" author="main-service">
+        <createTable tableName="post_files">
+            <column name="post_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="file_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint
+            baseTableName="post_files"
+            baseColumnNames="post_id"
+            constraintName="FK_post_files_post_id"
+            referencedTableName="posts"
+            referencedColumnNames="post_id"
+            onDelete="CASCADE"/>
+
+        <addForeignKeyConstraint
+            baseTableName="post_files"
+            baseColumnNames="file_id"
+            constraintName="FK_post_files_file_id"
+            referencedTableName="files"
+            referencedColumnNames="file_id"
+            onDelete="CASCADE"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/services/main-service/src/main/resources/db/changelog/changes/006-create-post-files-table.xml
+++ b/services/main-service/src/main/resources/db/changelog/changes/006-create-post-files-table.xml
@@ -6,7 +6,12 @@
         https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
     <!-- ManyToMany join table between posts and files -->
-    <changeSet id="006-create-post-files-table" author="main-service">
+    <changeSet id="006-create-post-files-table" author="osama">
+        <preConditions onFail="MARK_RAN" onError="HALT"
+                       onFailMessage="Table 'post_files' already exists — skipping changeset 006-create-post-files-table"
+                       onErrorMessage="Precondition check failed unexpectedly for changeset 006-create-post-files-table — halting migration">
+            <not><tableExists tableName="post_files" schemaName="public"/></not>
+        </preConditions>
         <createTable tableName="post_files">
             <column name="post_id" type="BIGINT">
                 <constraints nullable="false"/>

--- a/services/main-service/src/main/resources/db/changelog/changes/007-create-comments-table.xml
+++ b/services/main-service/src/main/resources/db/changelog/changes/007-create-comments-table.xml
@@ -5,7 +5,12 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
-    <changeSet id="007-create-comments-table" author="main-service">
+    <changeSet id="007-create-comments-table" author="osama">
+        <preConditions onFail="MARK_RAN" onError="HALT"
+                       onFailMessage="Table 'comments' already exists — skipping changeset 007-create-comments-table"
+                       onErrorMessage="Precondition check failed unexpectedly for changeset 007-create-comments-table — halting migration">
+            <not><tableExists tableName="comments" schemaName="public"/></not>
+        </preConditions>
         <createTable tableName="comments">
             <column name="comment_id" type="BIGINT" defaultValueSequenceNext="comment_sequence">
                 <constraints primaryKey="true" primaryKeyName="PK_comments" nullable="false"/>

--- a/services/main-service/src/main/resources/db/changelog/changes/007-create-comments-table.xml
+++ b/services/main-service/src/main/resources/db/changelog/changes/007-create-comments-table.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="007-create-comments-table" author="main-service">
+        <createTable tableName="comments">
+            <column name="comment_id" type="BIGINT" defaultValueSequenceNext="comment_sequence">
+                <constraints primaryKey="true" primaryKeyName="PK_comments" nullable="false"/>
+            </column>
+            <column name="content" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_at" type="TIMESTAMP WITH TIME ZONE">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP WITH TIME ZONE"/>
+            <column name="author_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="post_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="parent_comment_id" type="BIGINT"/>
+        </createTable>
+
+        <addForeignKeyConstraint
+            baseTableName="comments"
+            baseColumnNames="author_id"
+            constraintName="FK_comments_author_id"
+            referencedTableName="user_profiles"
+            referencedColumnNames="user_id"
+            onDelete="CASCADE"/>
+
+        <addForeignKeyConstraint
+            baseTableName="comments"
+            baseColumnNames="post_id"
+            constraintName="FK_comments_post_id"
+            referencedTableName="posts"
+            referencedColumnNames="post_id"
+            onDelete="CASCADE"/>
+
+        <addForeignKeyConstraint
+            baseTableName="comments"
+            baseColumnNames="parent_comment_id"
+            constraintName="FK_comments_parent_comment_id"
+            referencedTableName="comments"
+            referencedColumnNames="comment_id"
+            onDelete="CASCADE"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/services/main-service/src/main/resources/db/changelog/changes/008-create-reactions-table.xml
+++ b/services/main-service/src/main/resources/db/changelog/changes/008-create-reactions-table.xml
@@ -6,7 +6,12 @@
         https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
     <!-- @Table(name="reactions"), @Entity(name="reactions") -->
-    <changeSet id="008-create-reactions-table" author="main-service">
+    <changeSet id="008-create-reactions-table" author="osama">
+        <preConditions onFail="MARK_RAN" onError="HALT"
+                       onFailMessage="Table 'reactions' already exists — skipping changeset 008-create-reactions-table"
+                       onErrorMessage="Precondition check failed unexpectedly for changeset 008-create-reactions-table — halting migration">
+            <not><tableExists tableName="reactions" schemaName="public"/></not>
+        </preConditions>
         <createTable tableName="reactions">
             <column name="reaction_id" type="BIGINT" defaultValueSequenceNext="reaction_sequence">
                 <constraints primaryKey="true" primaryKeyName="PK_reactions" nullable="false"/>

--- a/services/main-service/src/main/resources/db/changelog/changes/008-create-reactions-table.xml
+++ b/services/main-service/src/main/resources/db/changelog/changes/008-create-reactions-table.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!-- @Table(name="reactions"), @Entity(name="reactions") -->
+    <changeSet id="008-create-reactions-table" author="main-service">
+        <createTable tableName="reactions">
+            <column name="reaction_id" type="BIGINT" defaultValueSequenceNext="reaction_sequence">
+                <constraints primaryKey="true" primaryKeyName="PK_reactions" nullable="false"/>
+            </column>
+            <column name="reaction_type" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="author_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="reaction_target_type" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="target_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint
+            baseTableName="reactions"
+            baseColumnNames="author_id"
+            constraintName="FK_reactions_author_id"
+            referencedTableName="user_profiles"
+            referencedColumnNames="user_id"
+            onDelete="CASCADE"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/services/main-service/src/main/resources/db/changelog/changes/009-create-friendships-table.xml
+++ b/services/main-service/src/main/resources/db/changelog/changes/009-create-friendships-table.xml
@@ -6,7 +6,12 @@
         https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
     <!-- IDENTITY strategy: autoIncrement="true" is correct (not sequence-backed) -->
-    <changeSet id="009-create-friendships-table" author="main-service">
+    <changeSet id="009-create-friendships-table" author="osama">
+        <preConditions onFail="MARK_RAN" onError="HALT"
+                       onFailMessage="Table 'friendships' already exists — skipping changeset 009-create-friendships-table"
+                       onErrorMessage="Precondition check failed unexpectedly for changeset 009-create-friendships-table — halting migration">
+            <not><tableExists tableName="friendships" schemaName="public"/></not>
+        </preConditions>
         <createTable tableName="friendships">
             <column name="friendship_id" type="BIGINT" autoIncrement="true">
                 <constraints primaryKey="true" primaryKeyName="PK_friendships" nullable="false"/>

--- a/services/main-service/src/main/resources/db/changelog/changes/009-create-friendships-table.xml
+++ b/services/main-service/src/main/resources/db/changelog/changes/009-create-friendships-table.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!-- IDENTITY strategy: autoIncrement="true" is correct (not sequence-backed) -->
+    <changeSet id="009-create-friendships-table" author="main-service">
+        <createTable tableName="friendships">
+            <column name="friendship_id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" primaryKeyName="PK_friendships" nullable="false"/>
+            </column>
+            <column name="user_id1" type="BIGINT"/>
+            <column name="user_id2" type="BIGINT"/>
+            <column name="status" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_at" type="TIMESTAMP WITH TIME ZONE">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addUniqueConstraint
+            tableName="friendships"
+            columnNames="user_id1, user_id2"
+            constraintName="UniqueFriendship"/>
+
+        <addForeignKeyConstraint
+            baseTableName="friendships"
+            baseColumnNames="user_id1"
+            constraintName="FK_friendships_user_id1"
+            referencedTableName="user_profiles"
+            referencedColumnNames="user_id"
+            onDelete="CASCADE"/>
+
+        <addForeignKeyConstraint
+            baseTableName="friendships"
+            baseColumnNames="user_id2"
+            constraintName="FK_friendships_user_id2"
+            referencedTableName="user_profiles"
+            referencedColumnNames="user_id"
+            onDelete="CASCADE"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/services/main-service/src/main/resources/db/changelog/changes/010-create-profiles-table.xml
+++ b/services/main-service/src/main/resources/db/changelog/changes/010-create-profiles-table.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="010-create-profiles-table" author="main-service">
+        <createTable tableName="profiles">
+            <column name="profile_id" type="BIGINT" defaultValueSequenceNext="profile_sequence">
+                <constraints primaryKey="true" primaryKeyName="PK_profiles" nullable="false"/>
+            </column>
+            <column name="about_user" type="VARCHAR(255)"/>
+            <column name="bio" type="VARCHAR(255)"/>
+            <column name="image_url" type="VARCHAR(255)"/>
+            <column name="user_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="address_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint
+            baseTableName="profiles"
+            baseColumnNames="user_id"
+            constraintName="FK_profiles_user_id"
+            referencedTableName="user_profiles"
+            referencedColumnNames="user_id"
+            onDelete="CASCADE"/>
+
+        <addForeignKeyConstraint
+            baseTableName="profiles"
+            baseColumnNames="address_id"
+            constraintName="FK_profiles_address_id"
+            referencedTableName="address"
+            referencedColumnNames="address_id"
+            onDelete="CASCADE"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/services/main-service/src/main/resources/db/changelog/changes/010-create-profiles-table.xml
+++ b/services/main-service/src/main/resources/db/changelog/changes/010-create-profiles-table.xml
@@ -5,7 +5,12 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
-    <changeSet id="010-create-profiles-table" author="main-service">
+    <changeSet id="010-create-profiles-table" author="osama">
+        <preConditions onFail="MARK_RAN" onError="HALT"
+                       onFailMessage="Table 'profiles' already exists — skipping changeset 010-create-profiles-table"
+                       onErrorMessage="Precondition check failed unexpectedly for changeset 010-create-profiles-table — halting migration">
+            <not><tableExists tableName="profiles" schemaName="public"/></not>
+        </preConditions>
         <createTable tableName="profiles">
             <column name="profile_id" type="BIGINT" defaultValueSequenceNext="profile_sequence">
                 <constraints primaryKey="true" primaryKeyName="PK_profiles" nullable="false"/>

--- a/services/main-service/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/services/main-service/src/main/resources/db/changelog/db.changelog-master.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <includeAll path="db/changelog/changes/" relativeToChangelogFile="false"/>
+
+</databaseChangeLog>

--- a/services/main-service/src/test/resources/application.yml
+++ b/services/main-service/src/test/resources/application.yml
@@ -9,6 +9,8 @@ spring:
     hibernate:
       ddl-auto: create-drop
     show-sql: true
+  liquibase:
+    enabled: false
 
 # File upload directory for testing
 file:

--- a/services/notification-service/pom.xml
+++ b/services/notification-service/pom.xml
@@ -104,6 +104,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-core</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/services/notification-service/src/main/java/semsem/notificationservice/model/Notification.java
+++ b/services/notification-service/src/main/java/semsem/notificationservice/model/Notification.java
@@ -23,7 +23,8 @@ import java.time.LocalDateTime;
 public class Notification {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "notifications_sequence")
+    @SequenceGenerator(name = "notifications_sequence", sequenceName = "notifications_sequence", allocationSize = 50)
     private Long id;
 
     @Enumerated(EnumType.STRING)

--- a/services/notification-service/src/main/resources/application.yml
+++ b/services/notification-service/src/main/resources/application.yml
@@ -21,7 +21,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     show-sql: ${SHOW_SQL:true}
     properties:
       hibernate:
@@ -31,6 +31,9 @@ spring:
           batch_size: 20
         order_inserts: true
         order_updates: true
+  liquibase:
+    change-log: classpath:db/changelog/db.changelog-master.xml
+    enabled: true
 
   #===================== Kafka Configuration ==========================
   # Use port 29092 for local development (outside Docker)

--- a/services/notification-service/src/main/resources/db/changelog/changes/001-create-notifications-table.xml
+++ b/services/notification-service/src/main/resources/db/changelog/changes/001-create-notifications-table.xml
@@ -5,7 +5,12 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
-    <changeSet id="001-create-notifications-table" author="notification-service">
+    <changeSet id="001-create-notifications-table" author="osama">
+        <preConditions onFail="MARK_RAN" onError="HALT"
+                       onFailMessage="Table 'notifications' already exists — skipping changeset 001-create-notifications-table"
+                       onErrorMessage="Precondition check failed unexpectedly for changeset 001-create-notifications-table — halting migration">
+            <not><tableExists tableName="notifications" schemaName="public"/></not>
+        </preConditions>
         <createTable tableName="notifications">
             <column name="id" type="BIGINT" autoIncrement="true">
                 <constraints primaryKey="true" primaryKeyName="PK_notifications" nullable="false"/>

--- a/services/notification-service/src/main/resources/db/changelog/changes/001-create-notifications-table.xml
+++ b/services/notification-service/src/main/resources/db/changelog/changes/001-create-notifications-table.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="001-create-notifications-table" author="notification-service">
+        <createTable tableName="notifications">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" primaryKeyName="PK_notifications" nullable="false"/>
+            </column>
+            <column name="type" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="message" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="sender_id" type="BIGINT"/>
+            <column name="receiver_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="is_read" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+            <column name="read_at" type="TIMESTAMP"/>
+            <column name="created_at" type="TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="reference_id" type="BIGINT"/>
+            <column name="reference_type" type="VARCHAR(50)"/>
+        </createTable>
+
+        <createIndex indexName="idx_receiver_id" tableName="notifications">
+            <column name="receiver_id"/>
+        </createIndex>
+
+        <createIndex indexName="idx_receiver_read" tableName="notifications">
+            <column name="receiver_id"/>
+            <column name="is_read"/>
+        </createIndex>
+
+        <createIndex indexName="idx_created_at" tableName="notifications">
+            <column name="created_at"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/services/notification-service/src/main/resources/db/changelog/changes/002-migrate-ids-to-sequences.xml
+++ b/services/notification-service/src/main/resources/db/changelog/changes/002-migrate-ids-to-sequences.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="002-create-sequence-notifications" author="osama">
+        <preConditions onFail="MARK_RAN" onError="HALT"
+                       onFailMessage="Sequence 'notifications_sequence' already exists — skipping"
+                       onErrorMessage="Precondition check failed unexpectedly for 002-create-sequence-notifications — halting migration">
+            <not><sequenceExists sequenceName="notifications_sequence" schemaName="public"/></not>
+        </preConditions>
+        <createSequence sequenceName="notifications_sequence" startValue="1" incrementBy="50"/>
+    </changeSet>
+
+    <changeSet id="002-drop-identity-notifications" author="osama" dbms="postgresql">
+        <sql>ALTER TABLE notifications ALTER COLUMN id DROP IDENTITY IF EXISTS</sql>
+    </changeSet>
+
+    <changeSet id="002-seed-sequence-notifications" author="osama" dbms="postgresql">
+        <sql>SELECT setval('notifications_sequence', GREATEST(COALESCE((SELECT MAX(id) FROM notifications), 0) + 500, 1))</sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/services/notification-service/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/services/notification-service/src/main/resources/db/changelog/db.changelog-master.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <includeAll path="db/changelog/changes/" relativeToChangelogFile="false"/>
+
+</databaseChangeLog>


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                                        
  - Wire Liquibase into auth-service, main-service, notification-service
  - Add per-table changesets matching current schema                                                                                                                                                                                                
  - Switch `ddl-auto` from `update` → `validate`                                                                                                                                                                                                    
  - Migrate ID strategy from IDENTITY → SEQUENCE (auth, main)
                                                                                                                                                                                                                                                    
  ## Breaking changes
  - auth-service, main-service: requires running `005-migrate-ids-to-sequences` against existing DBs before deploy.                                                                                                                                 
                                                                                                                                                                                                                                                    
  ## Test plan
  - [ ] `mvn -pl services/auth-service verify`                                                                                                                                                                                                      
  - [ ] `mvn -pl services/main-service verify`                                                                                                                                                                                                      
  - [ ] `mvn -pl services/notification-service verify`
  - [ ] Apply changelogs to a staging DB snapshot; confirm `validate` passes                                                                                                                                                                        
  - [ ] Verify sequence values >= max(id) per table            