### PR TITLE
  refactor: extract swagger annotations from controllers into interfaces

### DIFF
--- a/services/auth-service/src/main/java/com/app/auth/controller/AuthController.java
+++ b/services/auth-service/src/main/java/com/app/auth/controller/AuthController.java
@@ -9,11 +9,6 @@ import com.app.auth.service.AuthService;
 import com.app.auth.service.DeviceService;
 import com.app.auth.service.OtpService;
 import com.app.auth.service.PasswordService;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -48,17 +43,7 @@ public class AuthController implements IAuthApi {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    // TODO: move @Operation + @ApiResponses from remaining methods to IAuthApi
-
     @Override
-    @Operation(
-            summary = "Verify registration OTP",
-            description = "Verifies the OTP sent during registration and completes the registration process, returning JWT tokens"
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Email verified successfully, tokens returned"),
-            @ApiResponse(responseCode = "400", description = "Invalid or expired OTP")
-    })
     @PostMapping("/verify-registration")
     public ResponseEntity<MyApiResponse<AuthResponse>> verifyRegistration(
             @Valid @RequestBody VerifyRegistrationRequest request,
@@ -71,14 +56,6 @@ public class AuthController implements IAuthApi {
     }
 
     @Override
-    @Operation(
-            summary = "User login",
-            description = "Authenticates a user with email and password and returns JWT tokens"
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Successfully authenticated"),
-            @ApiResponse(responseCode = "401", description = "Invalid credentials")
-    })
     @PostMapping("/login")
     public ResponseEntity<MyApiResponse<AuthResponse>> login(
             @Valid @RequestBody LoginRequest request,
@@ -93,30 +70,15 @@ public class AuthController implements IAuthApi {
     }
 
     @Override
-    @Operation(
-            summary = "Validate JWT token",
-            description = "Validates a JWT token and returns user information if valid"
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Token validation result returned")
-    })
     @PostMapping("/validate")
     public ResponseEntity<MyApiResponse<TokenValidationResponse>> validateToken(
-            @Parameter(description = "JWT token to validate") @RequestParam String token) {
+            @RequestParam String token) {
         TokenValidationResponse validationResponse = authService.validateToken(token);
         MyApiResponse<TokenValidationResponse> response = MyApiResponse.success("Token validated", validationResponse);
         return ResponseEntity.ok(response);
     }
 
     @Override
-    @Operation(
-            summary = "Validate JWT token from Authorization header",
-            description = "Validates a JWT token from the Authorization header"
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Token validation result returned")
-    })
-    @SecurityRequirement(name = "bearerAuth")
     @PostMapping("/validate-header")
     public ResponseEntity<MyApiResponse<TokenValidationResponse>> validateTokenFromHeader(HttpServletRequest request) {
         String token = extractTokenFromHeader(request);
@@ -131,14 +93,6 @@ public class AuthController implements IAuthApi {
     }
 
     @Override
-    @Operation(
-            summary = "User logout",
-            description = "Logs out the current user by revoking their access token"
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Successfully logged out")
-    })
-    @SecurityRequirement(name = "bearerAuth")
     @PostMapping("/logout")
     public ResponseEntity<MyApiResponse<Void>> logout(HttpServletRequest request) {
         String token = extractTokenFromHeader(request);
@@ -150,34 +104,18 @@ public class AuthController implements IAuthApi {
     }
 
     @Override
-    @Operation(
-            summary = "Logout from all devices",
-            description = "Revokes all tokens for a specific user, logging them out from all devices"
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Successfully logged out from all devices")
-    })
-    @SecurityRequirement(name = "bearerAuth")
     @PostMapping("/logout-all")
     public ResponseEntity<MyApiResponse<Void>> logoutAllDevices(
-            @Parameter(description = "User ID to logout from all devices") @RequestParam Long userId) {
+            @RequestParam Long userId) {
         authService.logoutAllDevices(userId);
         MyApiResponse<Void> response = MyApiResponse.success("Logged out from all devices successfully");
         return ResponseEntity.ok(response);
     }
 
     @Override
-    @Operation(
-            summary = "Get user device sessions",
-            description = "Returns a list of all active device sessions for the authenticated user"
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Device sessions retrieved successfully")
-    })
-    @SecurityRequirement(name = "bearerAuth")
     @GetMapping("/devices")
     public ResponseEntity<MyApiResponse<List<DeviceSessionResponse>>> getUserDevices(
-            @Parameter(description = "User ID") @RequestParam Long userId,
+            @RequestParam Long userId,
             HttpServletRequest request) {
         String currentToken = extractTokenFromHeader(request);
         List<DeviceSessionResponse> devices = deviceService.getUserDeviceSessions(userId, currentToken);
@@ -187,37 +125,20 @@ public class AuthController implements IAuthApi {
     }
 
     @Override
-    @Operation(
-            summary = "Logout from specific device",
-            description = "Revokes a specific device session by token ID"
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Successfully logged out from device")
-    })
-    @SecurityRequirement(name = "bearerAuth")
     @PostMapping("/logout-device")
     public ResponseEntity<MyApiResponse<Void>> logoutDevice(
             @Valid @RequestBody LogoutDeviceRequest request,
-            @Parameter(description = "User ID") @RequestParam Long userId) {
+            @RequestParam Long userId) {
         deviceService.logoutDevice(request, userId);
         MyApiResponse<Void> response = MyApiResponse.success("Device logged out successfully");
         return ResponseEntity.ok(response);
     }
 
     @Override
-    @Operation(
-            summary = "Change password",
-            description = "Changes the user's password and invalidates all existing sessions"
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Password changed successfully"),
-            @ApiResponse(responseCode = "400", description = "Invalid password or password requirements not met")
-    })
-    @SecurityRequirement(name = "bearerAuth")
     @PostMapping("/change-password")
     public ResponseEntity<MyApiResponse<ChangePasswordResponse>> changePassword(
             @Valid @RequestBody ChangePasswordRequest request,
-            @Parameter(description = "User ID") @RequestParam Long userId) {
+            @RequestParam Long userId) {
         ChangePasswordResponse changePasswordResponse = passwordService.changePassword(request, userId);
         MyApiResponse<ChangePasswordResponse> response = MyApiResponse.success(
                 "Password change processed", changePasswordResponse);
@@ -225,14 +146,6 @@ public class AuthController implements IAuthApi {
     }
 
     @Override
-    @Operation(
-            summary = "Forgot password",
-            description = "Sends a password reset OTP to the user's email address"
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Password reset OTP sent successfully"),
-            @ApiResponse(responseCode = "404", description = "User not found")
-    })
     @PostMapping("/forgot-password")
     public ResponseEntity<MyApiResponse<ForgotPasswordResponse>> forgotPassword(
             @Valid @RequestBody ForgotPasswordRequest request) {
@@ -243,14 +156,6 @@ public class AuthController implements IAuthApi {
     }
 
     @Override
-    @Operation(
-            summary = "Reset password",
-            description = "Resets the user's password using the OTP sent to their email"
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Password reset successfully"),
-            @ApiResponse(responseCode = "400", description = "Invalid OTP or password requirements not met")
-    })
     @PostMapping("/reset-password")
     public ResponseEntity<MyApiResponse<ResetPasswordResponse>> resetPassword(
             @Valid @RequestBody ResetPasswordRequest request) {

--- a/services/auth-service/src/main/java/com/app/auth/controller/swagger/IAuthApi.java
+++ b/services/auth-service/src/main/java/com/app/auth/controller/swagger/IAuthApi.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -32,41 +33,127 @@ public interface IAuthApi {
     ResponseEntity<MyApiResponse<RegistrationResponse>> register(
             @Valid @RequestBody RegisterRequest request);
 
-    // TODO: add @Operation + @ApiResponses for remaining methods
-
+    @Operation(
+            summary = "Verify registration OTP",
+            description = "Verifies the OTP sent during registration and completes the registration process, returning JWT tokens"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Email verified successfully, tokens returned"),
+            @ApiResponse(responseCode = "400", description = "Invalid or expired OTP")
+    })
     ResponseEntity<MyApiResponse<AuthResponse>> verifyRegistration(
             @Valid @RequestBody VerifyRegistrationRequest request,
             HttpServletRequest httpRequest);
 
+    @Operation(
+            summary = "User login",
+            description = "Authenticates a user with email and password and returns JWT tokens"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully authenticated"),
+            @ApiResponse(responseCode = "401", description = "Invalid credentials")
+    })
     ResponseEntity<MyApiResponse<AuthResponse>> login(
             @Valid @RequestBody LoginRequest request,
             HttpServletRequest httpRequest);
 
+    @Operation(
+            summary = "Validate JWT token",
+            description = "Validates a JWT token and returns user information if valid"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Token validation result returned")
+    })
     ResponseEntity<MyApiResponse<TokenValidationResponse>> validateToken(
             @Parameter(description = "JWT token to validate") @RequestParam String token);
 
+    @Operation(
+            summary = "Validate JWT token from Authorization header",
+            description = "Validates a JWT token from the Authorization header"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Token validation result returned")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     ResponseEntity<MyApiResponse<TokenValidationResponse>> validateTokenFromHeader(HttpServletRequest request);
 
+    @Operation(
+            summary = "User logout",
+            description = "Logs out the current user by revoking their access token"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully logged out")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     ResponseEntity<MyApiResponse<Void>> logout(HttpServletRequest request);
 
+    @Operation(
+            summary = "Logout from all devices",
+            description = "Revokes all tokens for a specific user, logging them out from all devices"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully logged out from all devices")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     ResponseEntity<MyApiResponse<Void>> logoutAllDevices(
             @Parameter(description = "User ID to logout from all devices") @RequestParam Long userId);
 
+    @Operation(
+            summary = "Get user device sessions",
+            description = "Returns a list of all active device sessions for the authenticated user"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Device sessions retrieved successfully")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     ResponseEntity<MyApiResponse<List<DeviceSessionResponse>>> getUserDevices(
             @Parameter(description = "User ID") @RequestParam Long userId,
             HttpServletRequest request);
 
+    @Operation(
+            summary = "Logout from specific device",
+            description = "Revokes a specific device session by token ID"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully logged out from device")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     ResponseEntity<MyApiResponse<Void>> logoutDevice(
             @Valid @RequestBody LogoutDeviceRequest request,
             @Parameter(description = "User ID") @RequestParam Long userId);
 
+    @Operation(
+            summary = "Change password",
+            description = "Changes the user's password and invalidates all existing sessions"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Password changed successfully"),
+            @ApiResponse(responseCode = "400", description = "Invalid password or password requirements not met")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     ResponseEntity<MyApiResponse<ChangePasswordResponse>> changePassword(
             @Valid @RequestBody ChangePasswordRequest request,
             @Parameter(description = "User ID") @RequestParam Long userId);
 
+    @Operation(
+            summary = "Forgot password",
+            description = "Sends a password reset OTP to the user's email address"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Password reset OTP sent successfully"),
+            @ApiResponse(responseCode = "404", description = "User not found")
+    })
     ResponseEntity<MyApiResponse<ForgotPasswordResponse>> forgotPassword(
             @Valid @RequestBody ForgotPasswordRequest request);
 
+    @Operation(
+            summary = "Reset password",
+            description = "Resets the user's password using the OTP sent to their email"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Password reset successfully"),
+            @ApiResponse(responseCode = "400", description = "Invalid OTP or password requirements not met")
+    })
     ResponseEntity<MyApiResponse<ResetPasswordResponse>> resetPassword(
             @Valid @RequestBody ResetPasswordRequest request);
 }

--- a/services/main-service/src/main/java/com/app/server/controller/CommentController.java
+++ b/services/main-service/src/main/java/com/app/server/controller/CommentController.java
@@ -1,21 +1,16 @@
 package com.app.server.controller;
 
+import com.app.server.controller.swagger.ICommentApi;
 import com.app.server.dto.request.comment.AddNewCommentRequestDto;
 import com.app.server.dto.request.comment.GetAllCommentRepliesRequestDto;
 import com.app.server.dto.request.comment.GetAllCommentsRequestDto;
 import com.app.server.dto.request.comment.UpdateCommentRequestDto;
-import com.app.server.repository.UserProfileRepository;
-import com.app.shared.security.dto.MyApiResponse;
 import com.app.server.dto.response.comment.CommentResponseDto;
 import com.app.server.model.UserProfile;
+import com.app.server.repository.UserProfileRepository;
 import com.app.server.service.CommentService;
+import com.app.shared.security.dto.MyApiResponse;
 import com.app.shared.security.utils.SecurityUtils;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -27,9 +22,7 @@ import java.util.Set;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/comment")
-@Tag(name = "Comments", description = "APIs for managing comments on posts")
-@SecurityRequirement(name = "jwtAuth")
-public class CommentController {
+public class CommentController implements ICommentApi {
     private final CommentService commentService;
     private final UserProfileRepository userProfileRepository;
 
@@ -38,11 +31,8 @@ public class CommentController {
         return userProfileRepository.findUserByUserId(userId)
                 .orElseThrow(() -> new RuntimeException("User profile not found for userId: " + userId));
     }
-    @Operation(summary = "Add a new comment", description = "Add a new comment to a post")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Comment added successfully"),
-        @ApiResponse(responseCode = "401", description = "Unauthorized")
-    })
+
+    @Override
     @PostMapping("/add-new")
     public ResponseEntity<MyApiResponse<Boolean>> writeComment(
             @RequestBody AddNewCommentRequestDto commentDto
@@ -55,15 +45,10 @@ public class CommentController {
         );
     }
 
-    @Operation(summary = "Delete a comment", description = "Delete a comment by ID")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Comment deleted successfully"),
-        @ApiResponse(responseCode = "401", description = "Unauthorized"),
-        @ApiResponse(responseCode = "403", description = "Forbidden - not comment owner")
-    })
+    @Override
     @DeleteMapping ("/delete/{comment_id}")
     public ResponseEntity<MyApiResponse<Boolean>> deleteComment(
-            @Parameter(description = "Comment ID to delete") @PathVariable("comment_id") Long commentId
+            @PathVariable("comment_id") Long commentId
     ){
         UserProfile currentUserProfile = getCurrentUserProfile();
         return ResponseEntity.ok(
@@ -72,11 +57,7 @@ public class CommentController {
         );
     }
 
-    @Operation(summary = "Update a comment", description = "Update comment content")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Comment updated successfully"),
-        @ApiResponse(responseCode = "401", description = "Unauthorized")
-    })
+    @Override
     @PutMapping("/update")
     public ResponseEntity<MyApiResponse<Boolean>> updateComment(
             @RequestBody UpdateCommentRequestDto updateCommentRequestDto
@@ -86,11 +67,7 @@ public class CommentController {
         return ResponseEntity.ok(MyApiResponse.success("Comment updated successfully", updated));
     }
 
-    @Operation(summary = "Get all comments on a post", description = "Retrieve all comments for a specific post")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Comments retrieved successfully"),
-        @ApiResponse(responseCode = "401", description = "Unauthorized")
-    })
+    @Override
     @GetMapping("/all")
     public ResponseEntity<MyApiResponse<Set<CommentResponseDto>>> allCommentsOnPost(
             @ModelAttribute GetAllCommentsRequestDto getAllCommentsRequestDto
@@ -100,36 +77,28 @@ public class CommentController {
         return ResponseEntity.ok(MyApiResponse.success("All comments fetched successfully", retrievedComments));
     }
 
-    @Operation(summary = "Reply to a comment", description = "Add a reply to an existing comment")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Reply added successfully"),
-        @ApiResponse(responseCode = "401", description = "Unauthorized")
-    })
-     @PostMapping("/replay/{comment_id}")
-     public ResponseEntity<MyApiResponse<?>> replayOnComment(
-             @AuthenticationPrincipal UserDetails currentUserDetails,
-             @RequestBody AddNewCommentRequestDto addNewCommentRequestDto,
-             @Parameter(description = "Comment ID to reply to") @PathVariable("comment_id") Long commentId
-             ){
+    @Override
+    @PostMapping("/replay/{comment_id}")
+    public ResponseEntity<MyApiResponse<?>> replayOnComment(
+            @AuthenticationPrincipal UserDetails currentUserDetails,
+            @RequestBody AddNewCommentRequestDto addNewCommentRequestDto,
+            @PathVariable("comment_id") Long commentId
+            ){
         UserProfile currentUserProfile = getCurrentUserProfile();
 
         Boolean replayed = commentService.replayOnComment(currentUserProfile,addNewCommentRequestDto, commentId);
-         return ResponseEntity.ok(MyApiResponse.success("Reply added successfully", replayed));
-     }
+        return ResponseEntity.ok(MyApiResponse.success("Reply added successfully", replayed));
+    }
 
-    @Operation(summary = "Get all replies on a comment", description = "Retrieve all replies for a specific comment")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Replies retrieved successfully"),
-        @ApiResponse(responseCode = "401", description = "Unauthorized")
-    })
-     @GetMapping("/replies/all")
-     public ResponseEntity<MyApiResponse<?>> allRepliesOnComment(
-             @ModelAttribute GetAllCommentRepliesRequestDto getAllReplies
-             ){
+    @Override
+    @GetMapping("/replies/all")
+    public ResponseEntity<MyApiResponse<?>> allRepliesOnComment(
+            @ModelAttribute GetAllCommentRepliesRequestDto getAllReplies
+            ){
         UserProfile currentUserProfile = getCurrentUserProfile();
-         Set<CommentResponseDto> retrievedReplies= commentService.getCommentReplies(currentUserProfile, getAllReplies);
-         return ResponseEntity.ok(MyApiResponse.success("All replies fetched successfully", retrievedReplies));
-     }
-    
+        Set<CommentResponseDto> retrievedReplies= commentService.getCommentReplies(currentUserProfile, getAllReplies);
+        return ResponseEntity.ok(MyApiResponse.success("All replies fetched successfully", retrievedReplies));
+    }
+
 
 }

--- a/services/main-service/src/main/java/com/app/server/controller/FeedController.java
+++ b/services/main-service/src/main/java/com/app/server/controller/FeedController.java
@@ -1,17 +1,10 @@
 package com.app.server.controller;
 
+import com.app.server.controller.swagger.IFeedApi;
 import com.app.server.dto.response.FeedResponseDto;
 import com.app.server.feed.FeedService;
 import com.app.shared.security.dto.MyApiResponse;
 import com.app.shared.security.utils.SecurityUtils;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -23,31 +16,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/feed")
-@Tag(name = "News Feed", description = "Personalized news feed — shows posts authored by friends and posts friends reacted to or commented on")
-@SecurityRequirement(name = "jwtAuth")
-public class FeedController {
+public class FeedController implements IFeedApi {
 
     private final FeedService feedService;
 
-    @Operation(
-        summary = "Get personalized news feed",
-        description = "Returns a cursor-paginated feed of posts from friends and posts friends interacted with. " +
-                      "Pass the `nextCursor` from the previous response as `cursor` to load the next page. " +
-                      "Omit `cursor` on the first request to start from the most recent posts."
-    )
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Feed retrieved successfully",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
-        @ApiResponse(responseCode = "401", description = "Unauthorized — JWT token missing or invalid",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class)))
-    })
+    @Override
     @GetMapping
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     public ResponseEntity<MyApiResponse<FeedResponseDto>> getFeed(
-            @Parameter(description = "Epoch milliseconds of the last item from the previous page. Omit for the first request.")
             @RequestParam(required = false) Long cursor,
-
-            @Parameter(description = "Number of posts to return per page (default 20)")
             @RequestParam(defaultValue = "20") int size
     ) {
         Long userId = SecurityUtils.getCurrentUserId();

--- a/services/main-service/src/main/java/com/app/server/controller/FilesController.java
+++ b/services/main-service/src/main/java/com/app/server/controller/FilesController.java
@@ -1,29 +1,23 @@
 package com.app.server.controller;
 
+import com.app.server.controller.swagger.IFilesApi;
 import com.app.server.dto.request.file.GetFileRequestDto;
 import com.app.server.service.FileService;
 import com.app.shared.security.dto.MyApiResponse;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/files")
-@Tag(name = "Files", description = "APIs for secure file access and streaming")
-@SecurityRequirement(name = "jwtAuth")
 @Slf4j
 @RequiredArgsConstructor
-public class FilesController {
+public class FilesController implements IFilesApi {
     private final FileService fileService;
 
     /**
@@ -37,25 +31,11 @@ public class FilesController {
      * @param rangeHeader HTTP Range header for partial content requests (e.g., "bytes=0-1023")
      * @return File content with appropriate headers
      */
-    @Operation(
-        summary = "Get file with security and streaming support",
-        description = "Download or stream a file using query parameters. Supports HTTP Range requests for large files. " +
-                     "Validates user has access to the file. " +
-                     "Example: GET /api/v1/files?filename=posts/file.jpg&inline=true"
-    )
+    @Override
     @GetMapping
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     public ResponseEntity<Resource> getFile(
             @Valid @ModelAttribute GetFileRequestDto getFileRequestDto,
-
-            @Parameter(
-                description = "HTTP Range header for partial content streaming. " +
-                             "Format: 'bytes=start-end'. Examples: 'bytes=0-1023' (first 1KB), " +
-                             "'bytes=1000-' (from byte 1000 to end), 'bytes=-500' (last 500 bytes). " +
-                             "Enables video seeking, resume downloads, and progressive loading.",
-                example = "bytes=0-1023",
-                required = false
-            )
             @RequestHeader(value = HttpHeaders.RANGE, required = false) String rangeHeader
     ) {
         ResponseEntity<Resource> fileResource = fileService.getFile(getFileRequestDto, rangeHeader);
@@ -69,10 +49,11 @@ public class FilesController {
      * @param fileName The file to get URL for
      * @return Secure URL that requires authentication
      */
+    @Override
     @GetMapping("/url")
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     public ResponseEntity<MyApiResponse<String>> getContentUrl(
-            @Parameter(description = "File name to get secure URL for") @RequestParam String fileName
+            @RequestParam String fileName
     ) {
         String getFileAccessUrl = fileService.getFileUrl(fileName);
         return ResponseEntity.ok(

--- a/services/main-service/src/main/java/com/app/server/controller/FriendshipController.java
+++ b/services/main-service/src/main/java/com/app/server/controller/FriendshipController.java
@@ -1,18 +1,13 @@
 package com.app.server.controller;
 
 
+import com.app.server.controller.swagger.IFriendshipApi;
 import com.app.server.dto.response.AppUserResponseDto;
-import com.app.shared.security.dto.MyApiResponse;
 import com.app.server.model.UserProfile;
 import com.app.server.repository.UserProfileRepository;
 import com.app.server.service.FriendshipService;
+import com.app.shared.security.dto.MyApiResponse;
 import com.app.shared.security.utils.SecurityUtils;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -23,11 +18,9 @@ import java.util.Set;
 
 @Slf4j
 @RestController
-@Tag(name = "Friendship", description = "APIs for managing friendships and friend requests")
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/friendship")
-@SecurityRequirement(name = "jwtAuth")
-public class FriendshipController {
+public class FriendshipController implements IFriendshipApi {
 
     private final FriendshipService friendshipService;
     private final UserProfileRepository userProfileRepository;
@@ -38,95 +31,67 @@ public class FriendshipController {
                 .orElseThrow(() -> new RuntimeException("User profile not found for userId: " + userId));
     }
 
-    @Operation(summary = "Send friend request", description = "Send a friend request to another user")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Friend request sent successfully"),
-        @ApiResponse(responseCode = "401", description = "Unauthorized")
-    })
+    @Override
     @PostMapping("/add-friend/{friend_id}")
     public ResponseEntity<MyApiResponse<Boolean>> addFriend(
-            @Parameter(description = "User ID to send friend request to") @PathVariable("friend_id") Long friendId
+            @PathVariable("friend_id") Long friendId
     ) {
         UserProfile currentUser = getCurrentUserProfile();
         boolean isAdded = friendshipService.addFriend(currentUser, friendId);
         return ResponseEntity.ok(MyApiResponse.success("Friend request sent", isAdded));
     }
 
-    @Operation(summary = "Remove friend", description = "Remove a friend from your friend list")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Friend removed successfully"),
-        @ApiResponse(responseCode = "401", description = "Unauthorized")
-    })
+    @Override
     @DeleteMapping("/remove-friend/{friend_id}")
     public ResponseEntity<MyApiResponse<Boolean>> removeFriend(
-            @Parameter(description = "Friend ID to remove") @PathVariable("friend_id") Long friendId
+            @PathVariable("friend_id") Long friendId
     ) {
         UserProfile currentUser = getCurrentUserProfile();
         boolean isRemoved = friendshipService.removeFriend(currentUser, friendId);
         return ResponseEntity.ok(MyApiResponse.success( "Friend removed",isRemoved));
     }
 
-    @Operation(summary = "Accept friend request", description = "Accept a pending friend request")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Friend request accepted successfully"),
-        @ApiResponse(responseCode = "401", description = "Unauthorized")
-    })
+    @Override
     @PutMapping("/accept-friend/{friend_id}")
     public ResponseEntity<MyApiResponse<Boolean>> acceptFriend(
-            @Parameter(description = "User ID whose friend request to accept") @PathVariable("friend_id") Long friendId
+            @PathVariable("friend_id") Long friendId
     ) {
         UserProfile currentUser = getCurrentUserProfile();
         boolean isAccepted = friendshipService.acceptFriend(currentUser, friendId);
         return ResponseEntity.ok(MyApiResponse.success( "Friend request accepted", isAccepted));
     }
 
-    @Operation(summary = "Cancel friend request", description = "Cancel a sent friend request")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Friend request cancelled successfully"),
-        @ApiResponse(responseCode = "401", description = "Unauthorized")
-    })
+    @Override
     @DeleteMapping("/cancel-friend-request/{friend_id}")
     public ResponseEntity<MyApiResponse<Boolean>> cancelFriendRequest(
-            @Parameter(description = "User ID to cancel friend request for") @PathVariable("friend_id") Long friendId
+            @PathVariable("friend_id") Long friendId
     ) {
         UserProfile currentUser = getCurrentUserProfile();
         boolean isCancelled = friendshipService.cancelFriendRequest(currentUser, friendId);
         return ResponseEntity.ok(MyApiResponse.success("Friend request cancelled",isCancelled));
     }
 
-    @Operation(summary = "Block friend", description = "Block a user")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Friend blocked successfully"),
-        @ApiResponse(responseCode = "401", description = "Unauthorized")
-    })
+    @Override
     @PutMapping("/block-friend/{friend_id}")
     public ResponseEntity<MyApiResponse<Boolean>> blockFriend(
-            @Parameter(description = "User ID to block") @PathVariable("friend_id") Long friendId
+            @PathVariable("friend_id") Long friendId
     ) {
         UserProfile currentUser = getCurrentUserProfile();
         boolean isBlocked = friendshipService.blockFriend(currentUser, friendId);
         return ResponseEntity.ok(MyApiResponse.success( "Friend blocked",isBlocked));
     }
 
-    @Operation(summary = "Unblock friend", description = "Unblock a previously blocked user")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Friend unblocked successfully"),
-        @ApiResponse(responseCode = "401", description = "Unauthorized")
-    })
+    @Override
     @PutMapping("/unblock-friend/{friend_id}")
     public ResponseEntity<MyApiResponse<Boolean>> unblockFriend(
-            @Parameter(description = "User ID to unblock") @PathVariable("friend_id") Long friendId
+            @PathVariable("friend_id") Long friendId
     ) {
         UserProfile currentUser = getCurrentUserProfile();
         boolean isUnblocked = friendshipService.unblockFriend(currentUser, friendId);
         return ResponseEntity.ok(MyApiResponse.success( "Friend unblocked",isUnblocked));
     }
 
-    @Operation(summary = "Get friends", description = "Retrieve list of all friends")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Friends retrieved successfully"),
-        @ApiResponse(responseCode = "401", description = "Unauthorized")
-    })
+    @Override
     @GetMapping("/get-friends")
     public ResponseEntity<MyApiResponse<Set<AppUserResponseDto>>> getFriends() {
         UserProfile currentUser = getCurrentUserProfile();
@@ -135,11 +100,7 @@ public class FriendshipController {
         return ResponseEntity.ok(MyApiResponse.success( "Friends retrieved",friends));
     }
 
-    @Operation(summary = "Get friend requests", description = "Retrieve list of pending friend requests")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Friend requests retrieved successfully"),
-        @ApiResponse(responseCode = "401", description = "Unauthorized")
-    })
+    @Override
     @GetMapping("/get-friend-requests")
     public ResponseEntity<MyApiResponse<Set<AppUserResponseDto>>> getFriendRequests() {
         UserProfile currentUser = getCurrentUserProfile();
@@ -147,39 +108,27 @@ public class FriendshipController {
         return ResponseEntity.ok(MyApiResponse.success( "Friend requests retrieved",friendRequests));
     }
 
-    @Operation(summary = "Get mutual friends count", description = "Get count of mutual friends with another user")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Mutual friends count retrieved successfully"),
-        @ApiResponse(responseCode = "401", description = "Unauthorized")
-    })
+    @Override
     @GetMapping("/get-mutual-friends-count/{friend_id}")
     public ResponseEntity<MyApiResponse<Integer>> getMutualFriendsCount(
-            @Parameter(description = "User ID to check mutual friends with") @PathVariable("friend_id") Long friendId
+            @PathVariable("friend_id") Long friendId
     ) {
         UserProfile currentUser = getCurrentUserProfile();
         int mutualFriendsCount = friendshipService.getMutualFriendsCount(currentUser, friendId);
         return ResponseEntity.ok(MyApiResponse.success( "Mutual friends count retrieved",mutualFriendsCount));
     }
 
-    @Operation(summary = "Get mutual friends", description = "Retrieve list of mutual friends with another user")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Mutual friends retrieved successfully"),
-        @ApiResponse(responseCode = "401", description = "Unauthorized")
-    })
+    @Override
     @GetMapping("/get-mutual-friends/{friend_id}")
     public ResponseEntity<MyApiResponse<Set<AppUserResponseDto>>> getMutualFriends(
-            @Parameter(description = "User ID to get mutual friends with") @PathVariable("friend_id") Long friendId
+            @PathVariable("friend_id") Long friendId
     ) {
         UserProfile currentUser = getCurrentUserProfile();
         Set<AppUserResponseDto> mutualFriends = friendshipService.getMutualFriends(currentUser, friendId);
         return ResponseEntity.ok(MyApiResponse.success( "Mutual friends retrieved",mutualFriends));
     }
 
-    @Operation(summary = "Suggest friends", description = "Get friend suggestions based on mutual connections")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Suggested friends retrieved successfully"),
-        @ApiResponse(responseCode = "401", description = "Unauthorized")
-    })
+    @Override
     @GetMapping("/suggest-friends")
     public ResponseEntity<MyApiResponse<Set<AppUserResponseDto>>> suggestFriends(
     ) {
@@ -188,15 +137,11 @@ public class FriendshipController {
         return ResponseEntity.ok(MyApiResponse.success("Suggested friends retrieved", suggestedFriends));
     }
 
-    @Operation(summary = "Get friends paginated", description = "Retrieve paginated list of friends for chat")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Friends retrieved successfully"),
-        @ApiResponse(responseCode = "401", description = "Unauthorized")
-    })
+    @Override
     @GetMapping("/get-friends-paginated")
     public ResponseEntity<MyApiResponse<Page<AppUserResponseDto>>> getFriendsPaginated(
-            @Parameter(description = "Page number (0-indexed)") @RequestParam(defaultValue = "0") int page,
-            @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
     ) {
         Long currentUserId = SecurityUtils.getCurrentUserId();
         log.info("Fetching paginated friends list: userId={} page={}, size={}", currentUserId, page, size);

--- a/services/main-service/src/main/java/com/app/server/controller/PostController.java
+++ b/services/main-service/src/main/java/com/app/server/controller/PostController.java
@@ -1,21 +1,14 @@
 package com.app.server.controller;
 
+import com.app.server.controller.swagger.IPostApi;
 import com.app.server.dto.request.post.CreatePostRequestDto;
 import com.app.server.dto.request.post.GetRecentPostsRequestDto;
 import com.app.server.dto.request.post.UpdatePostRequestDto;
-import com.app.shared.security.dto.MyApiResponse;
 import com.app.server.dto.response.PostResponseDto;
 import com.app.server.model.Post;
 import com.app.server.service.PostService;
+import com.app.shared.security.dto.MyApiResponse;
 import com.app.shared.security.utils.SecurityUtils;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,24 +18,15 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.Set;
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/post")
-@Tag(name = "Posts", description = "APIs for managing posts")
-@SecurityRequirement(name = "jwtAuth")
-public class PostController {
+public class PostController implements IPostApi {
     private final PostService postService;
 
-    @Operation(summary = "Create a new post", description = "Create a new post with text and optional images")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Post created successfully",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
-        @ApiResponse(responseCode = "401", description = "Unauthorized",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class)))
-    })
+    @Override
     @PostMapping(value = "/create", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     public ResponseEntity<MyApiResponse<Boolean>> savePost(@Valid @ModelAttribute CreatePostRequestDto createPostRequestDto
@@ -53,13 +37,7 @@ public class PostController {
         return ResponseEntity.ok(MyApiResponse.success("Post created successfully", savedPost != null));
     }
 
-    @Operation(summary = "Get recent posts", description = "Retrieve recent posts for the feed")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Posts retrieved successfully",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
-        @ApiResponse(responseCode = "401", description = "Unauthorized",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class)))
-    })
+    @Override
     @GetMapping("/recent")
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     public ResponseEntity<MyApiResponse<List<PostResponseDto>>> allPosts(
@@ -71,19 +49,11 @@ public class PostController {
         return ResponseEntity.ok(MyApiResponse.success("All posts retrieved successfully", posts));
     }
 
-    @Operation(summary = "Delete a post", description = "Delete a post by ID (owner or admin only)")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Post deleted successfully",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
-        @ApiResponse(responseCode = "401", description = "Unauthorized",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
-        @ApiResponse(responseCode = "403", description = "Forbidden - not post owner",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class)))
-    })
+    @Override
     @DeleteMapping("/delete/{postId}")
     @PreAuthorize("hasRole('ADMIN') or @postService.isPostOwner(#postId, authentication.details.userId)")
     public ResponseEntity<MyApiResponse<Boolean>> deletePost(
-            @Parameter(description = "Post ID to delete") @PathVariable("postId") Long postId
+            @PathVariable("postId") Long postId
     ){
         Long currentUserId = SecurityUtils.getCurrentUserId();
         return ResponseEntity.ok(
@@ -92,13 +62,7 @@ public class PostController {
         );
     }
 
-    @Operation(summary = "Update a post", description = "Update post content")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Post updated successfully",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
-        @ApiResponse(responseCode = "401", description = "Unauthorized",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class)))
-    })
+    @Override
     @PutMapping("/update")
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     public ResponseEntity<MyApiResponse<Boolean>> updatePost(
@@ -111,19 +75,11 @@ public class PostController {
        );
     }
 
-    @Operation(summary = "Get post details", description = "Retrieve detailed information about a specific post")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Post details retrieved successfully",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
-        @ApiResponse(responseCode = "401", description = "Unauthorized",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
-        @ApiResponse(responseCode = "404", description = "Post not found",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class)))
-    })
+    @Override
     @GetMapping("/get-details/{postId}")
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     public ResponseEntity<MyApiResponse<PostResponseDto>> getPostDetails(
-            @Parameter(description = "Post ID to retrieve") @PathVariable("postId") Long postId
+            @PathVariable("postId") Long postId
     ){
         Long currentUserId = SecurityUtils.getCurrentUserId();
         PostResponseDto postResponseDto = postService.getPostDetails(currentUserId, postId);

--- a/services/main-service/src/main/java/com/app/server/controller/ProfileController.java
+++ b/services/main-service/src/main/java/com/app/server/controller/ProfileController.java
@@ -1,22 +1,16 @@
 package com.app.server.controller;
 
 
+import com.app.server.controller.swagger.IProfileApi;
 import com.app.server.dto.request.post.GetRecentPostsRequestDto;
 import com.app.server.dto.request.profile.UpdateProfileBioRequestDto;
-import com.app.shared.security.dto.MyApiResponse;
 import com.app.server.dto.response.PostResponseDto;
 import com.app.server.dto.response.profile.ProfileResponseDto;
 import com.app.server.model.UserProfile;
 import com.app.server.repository.UserProfileRepository;
 import com.app.server.service.ProfileService;
+import com.app.shared.security.dto.MyApiResponse;
 import com.app.shared.security.utils.SecurityUtils;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -25,15 +19,12 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
-import java.util.Set;
 
 
 @RestController
 @RequestMapping("/api/v1/profile")
 @RequiredArgsConstructor
-@Tag(name = "Profile", description = "APIs for managing user profiles")
-@SecurityRequirement(name = "jwtAuth")
-public class ProfileController {
+public class ProfileController implements IProfileApi {
 
     private final ProfileService profileService;
     private final UserProfileRepository userProfileRepository;
@@ -44,11 +35,7 @@ public class ProfileController {
                 .orElseThrow(() -> new RuntimeException("User profile not found for userId: " + userId));
     }
 
-    @Operation(summary = "Update profile bio", description = "Update user's profile biography")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Bio updated successfully"),
-        @ApiResponse(responseCode = "401", description = "Unauthorized")
-    })
+    @Override
     @PutMapping("/update/bio")
     public ResponseEntity<MyApiResponse<Boolean>> updateBio(
             @RequestBody UpdateProfileBioRequestDto bioRequestDto
@@ -58,11 +45,7 @@ public class ProfileController {
         return ResponseEntity.ok(MyApiResponse.success("Bio updated successfully", bioUpdated));
     }
 
-    @Operation(summary = "Update profile image", description = "Update user's profile picture")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Image updated successfully"),
-        @ApiResponse(responseCode = "401", description = "Unauthorized")
-    })
+    @Override
     @PutMapping(value = "/update/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<MyApiResponse<Boolean>> updateImage(
             @RequestParam("image") MultipartFile image
@@ -72,11 +55,7 @@ public class ProfileController {
         return ResponseEntity.ok(MyApiResponse.success("Image updated successfully", imageUpdated));
     }
 
-    @Operation(summary = "Get profile", description = "Retrieve current user's profile information")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Profile retrieved successfully"),
-        @ApiResponse(responseCode = "401", description = "Unauthorized")
-    })
+    @Override
     @GetMapping("/get")
     public ResponseEntity<MyApiResponse<ProfileResponseDto>> getProfile(){
         UserProfile currentUser = getCurrentUserProfile();
@@ -84,11 +63,7 @@ public class ProfileController {
         return ResponseEntity.ok(MyApiResponse.success("Profile retrieved successfully", profile));
     }
 
-    @Operation(summary = "Get user's posts", description = "Retrieve all posts created by the current user")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Posts retrieved successfully"),
-        @ApiResponse(responseCode = "401", description = "Unauthorized")
-    })
+    @Override
     @GetMapping("/posts")
     public ResponseEntity<MyApiResponse<?>> getMyPosts(
             @ModelAttribute @Valid GetRecentPostsRequestDto requestDto

--- a/services/main-service/src/main/java/com/app/server/controller/ReactionController.java
+++ b/services/main-service/src/main/java/com/app/server/controller/ReactionController.java
@@ -1,43 +1,28 @@
 package com.app.server.controller;
 
+import com.app.server.controller.swagger.IReactionApi;
 import com.app.server.dto.request.reaction.ReactToEntityRequestDto;
-import com.app.shared.security.dto.MyApiResponse;
-import com.app.server.model.UserProfile;
 import com.app.server.service.ReactionService;
+import com.app.shared.security.dto.MyApiResponse;
 import com.app.shared.security.utils.SecurityUtils;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 
 @Slf4j
 @RestController
-@Tag(name = "Reactions", description = "APIs for reactions on posts and comments")
 @RequiredArgsConstructor
-@SecurityRequirement(name = "jwtAuth")
-public class ReactionController {
+public class ReactionController implements IReactionApi {
 
     private final ReactionService reactionService;
 
-    @Operation(summary = "React to a post", description = "Add, update or remove a reaction on a post")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Reaction updated successfully"),
-        @ApiResponse(responseCode = "401", description = "Unauthorized"),
-        @ApiResponse(responseCode = "404", description = "Post not found")
-    })
+    @Override
     @PutMapping("/react/post/{post_id}")
     public ResponseEntity<MyApiResponse<Boolean>> reactToPost(
             @RequestBody ReactToEntityRequestDto reactToEntityRequestDto,
-            @Parameter(description = "Post ID to react to") @PathVariable("post_id") Long postId
+            @PathVariable("post_id") Long postId
     ){
         Long currentUserId = SecurityUtils.getCurrentUserId();
         log.debug("Received request to react to post with ID: {} , by user: {}", postId, currentUserId);
@@ -45,16 +30,11 @@ public class ReactionController {
         return ResponseEntity.ok(MyApiResponse.success("Reaction updated successfully", reacted));
     }
 
-    @Operation(summary = "React to a comment", description = "Add, update or remove a reaction on a comment")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Reaction updated successfully"),
-        @ApiResponse(responseCode = "401", description = "Unauthorized"),
-        @ApiResponse(responseCode = "404", description = "Comment not found")
-    })
+    @Override
     @PutMapping("/react/comment/{comment_id}")
     public ResponseEntity<MyApiResponse<Boolean>> reactToComment(
             @RequestBody ReactToEntityRequestDto reactToEntityRequestDto,
-            @Parameter(description = "Comment ID to react to") @PathVariable("comment_id") Long commentId
+            @PathVariable("comment_id") Long commentId
     ){
         Long currentUserId = SecurityUtils.getCurrentUserId();
         Boolean reacted = reactionService.reactToComment(currentUserId, reactToEntityRequestDto, commentId);

--- a/services/main-service/src/main/java/com/app/server/controller/swagger/ICommentApi.java
+++ b/services/main-service/src/main/java/com/app/server/controller/swagger/ICommentApi.java
@@ -1,0 +1,78 @@
+package com.app.server.controller.swagger;
+
+import com.app.server.dto.request.comment.AddNewCommentRequestDto;
+import com.app.server.dto.request.comment.GetAllCommentRepliesRequestDto;
+import com.app.server.dto.request.comment.GetAllCommentsRequestDto;
+import com.app.server.dto.request.comment.UpdateCommentRequestDto;
+import com.app.server.dto.response.comment.CommentResponseDto;
+import com.app.shared.security.dto.MyApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.Set;
+
+@Tag(name = "Comments", description = "APIs for managing comments on posts")
+@SecurityRequirement(name = "jwtAuth")
+public interface ICommentApi {
+
+    @Operation(summary = "Add a new comment", description = "Add a new comment to a post")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Comment added successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+    })
+    ResponseEntity<MyApiResponse<Boolean>> writeComment(
+            @RequestBody AddNewCommentRequestDto commentDto);
+
+    @Operation(summary = "Delete a comment", description = "Delete a comment by ID")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Comment deleted successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "403", description = "Forbidden - not comment owner")
+    })
+    ResponseEntity<MyApiResponse<Boolean>> deleteComment(
+            @Parameter(description = "Comment ID to delete") @PathVariable("comment_id") Long commentId);
+
+    @Operation(summary = "Update a comment", description = "Update comment content")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Comment updated successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+    })
+    ResponseEntity<MyApiResponse<Boolean>> updateComment(
+            @RequestBody UpdateCommentRequestDto updateCommentRequestDto);
+
+    @Operation(summary = "Get all comments on a post", description = "Retrieve all comments for a specific post")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Comments retrieved successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+    })
+    ResponseEntity<MyApiResponse<Set<CommentResponseDto>>> allCommentsOnPost(
+            @ModelAttribute GetAllCommentsRequestDto getAllCommentsRequestDto);
+
+    @Operation(summary = "Reply to a comment", description = "Add a reply to an existing comment")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Reply added successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+    })
+    ResponseEntity<MyApiResponse<?>> replayOnComment(
+            @AuthenticationPrincipal UserDetails currentUserDetails,
+            @RequestBody AddNewCommentRequestDto addNewCommentRequestDto,
+            @Parameter(description = "Comment ID to reply to") @PathVariable("comment_id") Long commentId);
+
+    @Operation(summary = "Get all replies on a comment", description = "Retrieve all replies for a specific comment")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Replies retrieved successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+    })
+    ResponseEntity<MyApiResponse<?>> allRepliesOnComment(
+            @ModelAttribute GetAllCommentRepliesRequestDto getAllReplies);
+}

--- a/services/main-service/src/main/java/com/app/server/controller/swagger/IFeedApi.java
+++ b/services/main-service/src/main/java/com/app/server/controller/swagger/IFeedApi.java
@@ -1,0 +1,38 @@
+package com.app.server.controller.swagger;
+
+import com.app.server.dto.response.FeedResponseDto;
+import com.app.shared.security.dto.MyApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "News Feed", description = "Personalized news feed — shows posts authored by friends and posts friends reacted to or commented on")
+@SecurityRequirement(name = "jwtAuth")
+public interface IFeedApi {
+
+    @Operation(
+            summary = "Get personalized news feed",
+            description = "Returns a cursor-paginated feed of posts from friends and posts friends interacted with. " +
+                    "Pass the `nextCursor` from the previous response as `cursor` to load the next page. " +
+                    "Omit `cursor` on the first request to start from the most recent posts."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Feed retrieved successfully",
+                    content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized — JWT token missing or invalid",
+                    content = @Content(schema = @Schema(implementation = MyApiResponse.class)))
+    })
+    ResponseEntity<MyApiResponse<FeedResponseDto>> getFeed(
+            @Parameter(description = "Epoch milliseconds of the last item from the previous page. Omit for the first request.")
+            @RequestParam(required = false) Long cursor,
+
+            @Parameter(description = "Number of posts to return per page (default 20)")
+            @RequestParam(defaultValue = "20") int size);
+}

--- a/services/main-service/src/main/java/com/app/server/controller/swagger/IFilesApi.java
+++ b/services/main-service/src/main/java/com/app/server/controller/swagger/IFilesApi.java
@@ -1,0 +1,42 @@
+package com.app.server.controller.swagger;
+
+import com.app.server.dto.request.file.GetFileRequestDto;
+import com.app.shared.security.dto.MyApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Files", description = "APIs for secure file access and streaming")
+@SecurityRequirement(name = "jwtAuth")
+public interface IFilesApi {
+
+    @Operation(
+            summary = "Get file with security and streaming support",
+            description = "Download or stream a file using query parameters. Supports HTTP Range requests for large files. " +
+                    "Validates user has access to the file. " +
+                    "Example: GET /api/v1/files?filename=posts/file.jpg&inline=true"
+    )
+    ResponseEntity<Resource> getFile(
+            @Valid @ModelAttribute GetFileRequestDto getFileRequestDto,
+
+            @Parameter(
+                    description = "HTTP Range header for partial content streaming. " +
+                            "Format: 'bytes=start-end'. Examples: 'bytes=0-1023' (first 1KB), " +
+                            "'bytes=1000-' (from byte 1000 to end), 'bytes=-500' (last 500 bytes). " +
+                            "Enables video seeking, resume downloads, and progressive loading.",
+                    example = "bytes=0-1023",
+                    required = false
+            )
+            @RequestHeader(value = HttpHeaders.RANGE, required = false) String rangeHeader);
+
+    ResponseEntity<MyApiResponse<String>> getContentUrl(
+            @Parameter(description = "File name to get secure URL for") @RequestParam String fileName);
+}

--- a/services/main-service/src/main/java/com/app/server/controller/swagger/IFriendshipApi.java
+++ b/services/main-service/src/main/java/com/app/server/controller/swagger/IFriendshipApi.java
@@ -1,0 +1,115 @@
+package com.app.server.controller.swagger;
+
+import com.app.server.dto.response.AppUserResponseDto;
+import com.app.shared.security.dto.MyApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.Set;
+
+@Tag(name = "Friendship", description = "APIs for managing friendships and friend requests")
+@SecurityRequirement(name = "jwtAuth")
+public interface IFriendshipApi {
+
+    @Operation(summary = "Send friend request", description = "Send a friend request to another user")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Friend request sent successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+    })
+    ResponseEntity<MyApiResponse<Boolean>> addFriend(
+            @Parameter(description = "User ID to send friend request to") @PathVariable("friend_id") Long friendId);
+
+    @Operation(summary = "Remove friend", description = "Remove a friend from your friend list")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Friend removed successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+    })
+    ResponseEntity<MyApiResponse<Boolean>> removeFriend(
+            @Parameter(description = "Friend ID to remove") @PathVariable("friend_id") Long friendId);
+
+    @Operation(summary = "Accept friend request", description = "Accept a pending friend request")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Friend request accepted successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+    })
+    ResponseEntity<MyApiResponse<Boolean>> acceptFriend(
+            @Parameter(description = "User ID whose friend request to accept") @PathVariable("friend_id") Long friendId);
+
+    @Operation(summary = "Cancel friend request", description = "Cancel a sent friend request")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Friend request cancelled successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+    })
+    ResponseEntity<MyApiResponse<Boolean>> cancelFriendRequest(
+            @Parameter(description = "User ID to cancel friend request for") @PathVariable("friend_id") Long friendId);
+
+    @Operation(summary = "Block friend", description = "Block a user")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Friend blocked successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+    })
+    ResponseEntity<MyApiResponse<Boolean>> blockFriend(
+            @Parameter(description = "User ID to block") @PathVariable("friend_id") Long friendId);
+
+    @Operation(summary = "Unblock friend", description = "Unblock a previously blocked user")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Friend unblocked successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+    })
+    ResponseEntity<MyApiResponse<Boolean>> unblockFriend(
+            @Parameter(description = "User ID to unblock") @PathVariable("friend_id") Long friendId);
+
+    @Operation(summary = "Get friends", description = "Retrieve list of all friends")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Friends retrieved successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+    })
+    ResponseEntity<MyApiResponse<Set<AppUserResponseDto>>> getFriends();
+
+    @Operation(summary = "Get friend requests", description = "Retrieve list of pending friend requests")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Friend requests retrieved successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+    })
+    ResponseEntity<MyApiResponse<Set<AppUserResponseDto>>> getFriendRequests();
+
+    @Operation(summary = "Get mutual friends count", description = "Get count of mutual friends with another user")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Mutual friends count retrieved successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+    })
+    ResponseEntity<MyApiResponse<Integer>> getMutualFriendsCount(
+            @Parameter(description = "User ID to check mutual friends with") @PathVariable("friend_id") Long friendId);
+
+    @Operation(summary = "Get mutual friends", description = "Retrieve list of mutual friends with another user")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Mutual friends retrieved successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+    })
+    ResponseEntity<MyApiResponse<Set<AppUserResponseDto>>> getMutualFriends(
+            @Parameter(description = "User ID to get mutual friends with") @PathVariable("friend_id") Long friendId);
+
+    @Operation(summary = "Suggest friends", description = "Get friend suggestions based on mutual connections")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Suggested friends retrieved successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+    })
+    ResponseEntity<MyApiResponse<Set<AppUserResponseDto>>> suggestFriends();
+
+    @Operation(summary = "Get friends paginated", description = "Retrieve paginated list of friends for chat")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Friends retrieved successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+    })
+    ResponseEntity<MyApiResponse<Page<AppUserResponseDto>>> getFriendsPaginated(
+            @Parameter(description = "Page number (0-indexed)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size);
+}

--- a/services/main-service/src/main/java/com/app/server/controller/swagger/IPostApi.java
+++ b/services/main-service/src/main/java/com/app/server/controller/swagger/IPostApi.java
@@ -1,0 +1,81 @@
+package com.app.server.controller.swagger;
+
+import com.app.server.dto.request.post.CreatePostRequestDto;
+import com.app.server.dto.request.post.GetRecentPostsRequestDto;
+import com.app.server.dto.request.post.UpdatePostRequestDto;
+import com.app.server.dto.response.PostResponseDto;
+import com.app.shared.security.dto.MyApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+@Tag(name = "Posts", description = "APIs for managing posts")
+@SecurityRequirement(name = "jwtAuth")
+public interface IPostApi {
+
+    @Operation(summary = "Create a new post", description = "Create a new post with text and optional images")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Post created successfully",
+                    content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized",
+                    content = @Content(schema = @Schema(implementation = MyApiResponse.class)))
+    })
+    ResponseEntity<MyApiResponse<Boolean>> savePost(
+            @Valid @ModelAttribute CreatePostRequestDto createPostRequestDto);
+
+    @Operation(summary = "Get recent posts", description = "Retrieve recent posts for the feed")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Posts retrieved successfully",
+                    content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized",
+                    content = @Content(schema = @Schema(implementation = MyApiResponse.class)))
+    })
+    ResponseEntity<MyApiResponse<List<PostResponseDto>>> allPosts(
+            @Valid @ModelAttribute GetRecentPostsRequestDto req);
+
+    @Operation(summary = "Delete a post", description = "Delete a post by ID (owner or admin only)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Post deleted successfully",
+                    content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized",
+                    content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden - not post owner",
+                    content = @Content(schema = @Schema(implementation = MyApiResponse.class)))
+    })
+    ResponseEntity<MyApiResponse<Boolean>> deletePost(
+            @Parameter(description = "Post ID to delete") @PathVariable("postId") Long postId);
+
+    @Operation(summary = "Update a post", description = "Update post content")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Post updated successfully",
+                    content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized",
+                    content = @Content(schema = @Schema(implementation = MyApiResponse.class)))
+    })
+    ResponseEntity<MyApiResponse<Boolean>> updatePost(
+            @Valid @RequestBody UpdatePostRequestDto requestDto);
+
+    @Operation(summary = "Get post details", description = "Retrieve detailed information about a specific post")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Post details retrieved successfully",
+                    content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized",
+                    content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Post not found",
+                    content = @Content(schema = @Schema(implementation = MyApiResponse.class)))
+    })
+    ResponseEntity<MyApiResponse<PostResponseDto>> getPostDetails(
+            @Parameter(description = "Post ID to retrieve") @PathVariable("postId") Long postId);
+}

--- a/services/main-service/src/main/java/com/app/server/controller/swagger/IProfileApi.java
+++ b/services/main-service/src/main/java/com/app/server/controller/swagger/IProfileApi.java
@@ -1,0 +1,53 @@
+package com.app.server.controller.swagger;
+
+import com.app.server.dto.request.post.GetRecentPostsRequestDto;
+import com.app.server.dto.request.profile.UpdateProfileBioRequestDto;
+import com.app.server.dto.response.profile.ProfileResponseDto;
+import com.app.shared.security.dto.MyApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "Profile", description = "APIs for managing user profiles")
+@SecurityRequirement(name = "jwtAuth")
+public interface IProfileApi {
+
+    @Operation(summary = "Update profile bio", description = "Update user's profile biography")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Bio updated successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+    })
+    ResponseEntity<MyApiResponse<Boolean>> updateBio(
+            @RequestBody UpdateProfileBioRequestDto bioRequestDto);
+
+    @Operation(summary = "Update profile image", description = "Update user's profile picture")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Image updated successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+    })
+    ResponseEntity<MyApiResponse<Boolean>> updateImage(
+            @RequestParam("image") MultipartFile image);
+
+    @Operation(summary = "Get profile", description = "Retrieve current user's profile information")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Profile retrieved successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+    })
+    ResponseEntity<MyApiResponse<ProfileResponseDto>> getProfile();
+
+    @Operation(summary = "Get user's posts", description = "Retrieve all posts created by the current user")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Posts retrieved successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+    })
+    ResponseEntity<MyApiResponse<?>> getMyPosts(
+            @ModelAttribute @Valid GetRecentPostsRequestDto requestDto);
+}

--- a/services/main-service/src/main/java/com/app/server/controller/swagger/IReactionApi.java
+++ b/services/main-service/src/main/java/com/app/server/controller/swagger/IReactionApi.java
@@ -1,0 +1,38 @@
+package com.app.server.controller.swagger;
+
+import com.app.server.dto.request.reaction.ReactToEntityRequestDto;
+import com.app.shared.security.dto.MyApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Reactions", description = "APIs for reactions on posts and comments")
+@SecurityRequirement(name = "jwtAuth")
+public interface IReactionApi {
+
+    @Operation(summary = "React to a post", description = "Add, update or remove a reaction on a post")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Reaction updated successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "404", description = "Post not found")
+    })
+    ResponseEntity<MyApiResponse<Boolean>> reactToPost(
+            @RequestBody ReactToEntityRequestDto reactToEntityRequestDto,
+            @Parameter(description = "Post ID to react to") @PathVariable("post_id") Long postId);
+
+    @Operation(summary = "React to a comment", description = "Add, update or remove a reaction on a comment")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Reaction updated successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "404", description = "Comment not found")
+    })
+    ResponseEntity<MyApiResponse<Boolean>> reactToComment(
+            @RequestBody ReactToEntityRequestDto reactToEntityRequestDto,
+            @Parameter(description = "Comment ID to react to") @PathVariable("comment_id") Long commentId);
+}

--- a/services/notification-service/src/main/java/semsem/notificationservice/controller/NotificationController.java
+++ b/services/notification-service/src/main/java/semsem/notificationservice/controller/NotificationController.java
@@ -2,14 +2,6 @@ package semsem.notificationservice.controller;
 
 import com.app.shared.security.dto.MyApiResponse;
 import com.app.shared.security.utils.SecurityUtils;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -18,6 +10,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import semsem.notificationservice.controller.swagger.INotificationApi;
 import semsem.notificationservice.dto.NotificationPageResponse;
 import semsem.notificationservice.dto.NotificationResponse;
 import semsem.notificationservice.enums.NotificationType;
@@ -27,24 +20,16 @@ import semsem.notificationservice.service.NotificationService;
 @RequestMapping("/api/notifications")
 @RequiredArgsConstructor
 @Slf4j
-@Tag(name = "Notification Management", description = "APIs for managing user notifications")
-@SecurityRequirement(name = "jwtAuth")
-public class NotificationController {
+public class NotificationController implements INotificationApi {
 
     private final NotificationService notificationService;
 
+    @Override
     @GetMapping
-    @Operation(summary = "Get all notifications for current user", description = "Retrieves paginated notifications for the authenticated user")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Notifications retrieved successfully",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
-        @ApiResponse(responseCode = "401", description = "Unauthorized",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class)))
-    })
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     public ResponseEntity<MyApiResponse<NotificationPageResponse>> getUserNotifications(
-            @Parameter(description = "Page number (0-indexed)") @RequestParam(defaultValue = "0") int page,
-            @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size) {
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
 
         Long currentUserId = SecurityUtils.getCurrentUserId();
         log.debug("Fetching notifications for user: {}, page: {}, size: {}", currentUserId, page, size);
@@ -53,18 +38,12 @@ public class NotificationController {
         return ResponseEntity.ok(MyApiResponse.success("Notifications retrieved successfully", response));
     }
 
+    @Override
     @GetMapping("/unread")
-    @Operation(summary = "Get unread notifications", description = "Retrieves paginated unread notifications for the authenticated user")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Unread notifications retrieved successfully",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
-        @ApiResponse(responseCode = "401", description = "Unauthorized",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class)))
-    })
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     public ResponseEntity<MyApiResponse<NotificationPageResponse>> getUnreadNotifications(
-            @Parameter(description = "Page number (0-indexed)") @RequestParam(defaultValue = "0") int page,
-            @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size) {
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
 
         Long currentUserId = SecurityUtils.getCurrentUserId();
         log.debug("Fetching unread notifications for user: {}", currentUserId);
@@ -73,19 +52,13 @@ public class NotificationController {
         return ResponseEntity.ok(MyApiResponse.success("Unread notifications retrieved successfully", response));
     }
 
+    @Override
     @GetMapping("/type/{type}")
-    @Operation(summary = "Get notifications by type", description = "Retrieves notifications of a specific type for the authenticated user")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Notifications retrieved successfully",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
-        @ApiResponse(responseCode = "401", description = "Unauthorized",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class)))
-    })
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     public ResponseEntity<MyApiResponse<Page<NotificationResponse>>> getNotificationsByType(
-            @Parameter(description = "Notification type") @PathVariable NotificationType type,
-            @Parameter(description = "Page number (0-indexed)") @RequestParam(defaultValue = "0") int page,
-            @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size) {
+            @PathVariable NotificationType type,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
 
         Long currentUserId = SecurityUtils.getCurrentUserId();
         log.debug("Fetching notifications by type: {} for user: {}", type, currentUserId);
@@ -94,14 +67,8 @@ public class NotificationController {
         return ResponseEntity.ok(MyApiResponse.success("Notifications retrieved successfully", notifications));
     }
 
+    @Override
     @GetMapping("/unread-count")
-    @Operation(summary = "Get unread notification count", description = "Returns the count of unread notifications for the authenticated user")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Unread count retrieved successfully",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
-        @ApiResponse(responseCode = "401", description = "Unauthorized",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class)))
-    })
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     public ResponseEntity<MyApiResponse<Long>> getUnreadCount() {
 
@@ -110,19 +77,11 @@ public class NotificationController {
         return ResponseEntity.ok(MyApiResponse.success("Unread count retrieved successfully", count));
     }
 
+    @Override
     @PutMapping("/{notificationId}/read")
-    @Operation(summary = "Mark notification as read", description = "Marks a specific notification as read for the authenticated user")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Notification marked as read",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
-        @ApiResponse(responseCode = "404", description = "Notification not found",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
-        @ApiResponse(responseCode = "401", description = "Unauthorized",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class)))
-    })
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     public ResponseEntity<MyApiResponse<Boolean>> markAsRead(
-            @Parameter(description = "Notification ID") @PathVariable Long notificationId) {
+            @PathVariable Long notificationId) {
 
         Long currentUserId = SecurityUtils.getCurrentUserId();
         log.info("Marking notification {} as read for user {}", notificationId, currentUserId);
@@ -130,14 +89,8 @@ public class NotificationController {
         return ResponseEntity.ok(MyApiResponse.success("Notification marked as read", true));
     }
 
+    @Override
     @PutMapping("/read-all")
-    @Operation(summary = "Mark all notifications as read", description = "Marks all unread notifications as read for the authenticated user")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "All notifications marked as read",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
-        @ApiResponse(responseCode = "401", description = "Unauthorized",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class)))
-    })
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     public ResponseEntity<MyApiResponse<Integer>> markAllAsRead() {
 
@@ -147,19 +100,11 @@ public class NotificationController {
         return ResponseEntity.ok(MyApiResponse.success("All notifications marked as read", updatedCount));
     }
 
+    @Override
     @DeleteMapping("/{notificationId}")
-    @Operation(summary = "Delete notification", description = "Deletes a specific notification for the authenticated user")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Notification deleted successfully",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
-        @ApiResponse(responseCode = "404", description = "Notification not found",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
-        @ApiResponse(responseCode = "401", description = "Unauthorized",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class)))
-    })
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     public ResponseEntity<MyApiResponse<Boolean>> deleteNotification(
-            @Parameter(description = "Notification ID") @PathVariable Long notificationId) {
+            @PathVariable Long notificationId) {
 
         Long currentUserId = SecurityUtils.getCurrentUserId();
         log.info("Deleting notification {} for user {}", notificationId, currentUserId);
@@ -167,14 +112,8 @@ public class NotificationController {
         return ResponseEntity.ok(MyApiResponse.success("Notification deleted successfully", true));
     }
 
+    @Override
     @DeleteMapping
-    @Operation(summary = "Delete all notifications", description = "Deletes all notifications for the authenticated user")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "All notifications deleted successfully",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
-        @ApiResponse(responseCode = "401", description = "Unauthorized",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class)))
-    })
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     public ResponseEntity<MyApiResponse<Boolean>> deleteAllNotifications() {
 
@@ -184,17 +123,11 @@ public class NotificationController {
         return ResponseEntity.ok(MyApiResponse.success("All notifications deleted successfully", true));
     }
 
+    @Override
     @DeleteMapping("/cleanup")
-    @Operation(summary = "Cleanup old notifications", description = "Admin endpoint to cleanup old read notifications")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Cleanup completed successfully",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
-        @ApiResponse(responseCode = "403", description = "Forbidden - Admin only",
-            content = @Content(schema = @Schema(implementation = MyApiResponse.class)))
-    })
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<MyApiResponse<Integer>> cleanupOldNotifications(
-            @Parameter(description = "Days old threshold") @RequestParam(defaultValue = "30") int daysOld) {
+            @RequestParam(defaultValue = "30") int daysOld) {
 
         log.info("Cleaning up notifications older than {} days", daysOld);
         int deletedCount = notificationService.cleanupOldNotifications(daysOld);

--- a/services/notification-service/src/main/java/semsem/notificationservice/controller/swagger/INotificationApi.java
+++ b/services/notification-service/src/main/java/semsem/notificationservice/controller/swagger/INotificationApi.java
@@ -1,0 +1,118 @@
+package semsem.notificationservice.controller.swagger;
+
+import com.app.shared.security.dto.MyApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import semsem.notificationservice.dto.NotificationPageResponse;
+import semsem.notificationservice.dto.NotificationResponse;
+import semsem.notificationservice.enums.NotificationType;
+
+@Tag(name = "Notification Management", description = "APIs for managing user notifications")
+@SecurityRequirement(name = "jwtAuth")
+public interface INotificationApi {
+
+    @Operation(summary = "Get all notifications for current user", description = "Retrieves paginated notifications for the authenticated user")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Notifications retrieved successfully",
+            content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
+        @ApiResponse(responseCode = "401", description = "Unauthorized",
+            content = @Content(schema = @Schema(implementation = MyApiResponse.class)))
+    })
+    ResponseEntity<MyApiResponse<NotificationPageResponse>> getUserNotifications(
+            @Parameter(description = "Page number (0-indexed)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size);
+
+    @Operation(summary = "Get unread notifications", description = "Retrieves paginated unread notifications for the authenticated user")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Unread notifications retrieved successfully",
+            content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
+        @ApiResponse(responseCode = "401", description = "Unauthorized",
+            content = @Content(schema = @Schema(implementation = MyApiResponse.class)))
+    })
+    ResponseEntity<MyApiResponse<NotificationPageResponse>> getUnreadNotifications(
+            @Parameter(description = "Page number (0-indexed)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size);
+
+    @Operation(summary = "Get notifications by type", description = "Retrieves notifications of a specific type for the authenticated user")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Notifications retrieved successfully",
+            content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
+        @ApiResponse(responseCode = "401", description = "Unauthorized",
+            content = @Content(schema = @Schema(implementation = MyApiResponse.class)))
+    })
+    ResponseEntity<MyApiResponse<Page<NotificationResponse>>> getNotificationsByType(
+            @Parameter(description = "Notification type") @PathVariable NotificationType type,
+            @Parameter(description = "Page number (0-indexed)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size);
+
+    @Operation(summary = "Get unread notification count", description = "Returns the count of unread notifications for the authenticated user")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Unread count retrieved successfully",
+            content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
+        @ApiResponse(responseCode = "401", description = "Unauthorized",
+            content = @Content(schema = @Schema(implementation = MyApiResponse.class)))
+    })
+    ResponseEntity<MyApiResponse<Long>> getUnreadCount();
+
+    @Operation(summary = "Mark notification as read", description = "Marks a specific notification as read for the authenticated user")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Notification marked as read",
+            content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
+        @ApiResponse(responseCode = "404", description = "Notification not found",
+            content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
+        @ApiResponse(responseCode = "401", description = "Unauthorized",
+            content = @Content(schema = @Schema(implementation = MyApiResponse.class)))
+    })
+    ResponseEntity<MyApiResponse<Boolean>> markAsRead(
+            @Parameter(description = "Notification ID") @PathVariable Long notificationId);
+
+    @Operation(summary = "Mark all notifications as read", description = "Marks all unread notifications as read for the authenticated user")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "All notifications marked as read",
+            content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
+        @ApiResponse(responseCode = "401", description = "Unauthorized",
+            content = @Content(schema = @Schema(implementation = MyApiResponse.class)))
+    })
+    ResponseEntity<MyApiResponse<Integer>> markAllAsRead();
+
+    @Operation(summary = "Delete notification", description = "Deletes a specific notification for the authenticated user")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Notification deleted successfully",
+            content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
+        @ApiResponse(responseCode = "404", description = "Notification not found",
+            content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
+        @ApiResponse(responseCode = "401", description = "Unauthorized",
+            content = @Content(schema = @Schema(implementation = MyApiResponse.class)))
+    })
+    ResponseEntity<MyApiResponse<Boolean>> deleteNotification(
+            @Parameter(description = "Notification ID") @PathVariable Long notificationId);
+
+    @Operation(summary = "Delete all notifications", description = "Deletes all notifications for the authenticated user")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "All notifications deleted successfully",
+            content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
+        @ApiResponse(responseCode = "401", description = "Unauthorized",
+            content = @Content(schema = @Schema(implementation = MyApiResponse.class)))
+    })
+    ResponseEntity<MyApiResponse<Boolean>> deleteAllNotifications();
+
+    @Operation(summary = "Cleanup old notifications", description = "Admin endpoint to cleanup old read notifications")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Cleanup completed successfully",
+            content = @Content(schema = @Schema(implementation = MyApiResponse.class))),
+        @ApiResponse(responseCode = "403", description = "Forbidden - Admin only",
+            content = @Content(schema = @Schema(implementation = MyApiResponse.class)))
+    })
+    ResponseEntity<MyApiResponse<Integer>> cleanupOldNotifications(
+            @Parameter(description = "Days old threshold") @RequestParam(defaultValue = "30") int daysOld);
+}


### PR DESCRIPTION
  Move @Tag, @Operation, @ApiResponses, @Parameter, and @SecurityRequirement
  from controller classes into companion I<Name>Api interfaces under a
  swagger/ subpackage. Controllers now implement these interfaces and keep
  only Spring routing and business logic.

  Applies to:
  - auth-service: AuthController -> IAuthApi from controller classes into companion I<Name>Api interfaces under a swagger/ subpackage. Controllers now implement these interfaces and keep only Spring routing and business logic.

  Applies to:
  - auth-service: AuthController -> IAuthApi
  - main-service: Comment, Feed, Files, Friendship, Post, Profile, Reaction
  - notification-service: NotificationController -> INotificationApi